### PR TITLE
Bug Logging And Toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Games made by Lemon.",
   "scripts": {
-    "dev": "concurrently -k \"npm run dev:client\" \"npm run watch:pages\"",
+    "dev": "set NODE_NO_WARNINGS=1 && concurrently --names \"CLIENT  ,WATCH   \" --prefix \"{name}|\" --prefix-colors \"magenta,cyan\" -k \"npm run dev:client\" \"npm run watch:pages\"",
     "dev:client": "vite",
     "dev:server": "concurrently --prefix none \"vite\" \"node src/server/express.js\" || (exit 0)",
     "build:pages": "node build-pages.js",
@@ -17,7 +17,7 @@
     "serve-heroku": "vite --host 0.0.0.0 --port $PORT preview --mode sandbox",
     "update-billionaires": "node scripts/update-billionaires-2024.js",
     "generate-arrests": "node scripts/generate-arrests.js",
-    "watch:pages": "concurrently -k \"nodemon -w src/views/cameo/Page.pug -x node build-pages.js cameo\" \"nodemon -w src/views/guillotine/Page.pug -x node build-pages.js guillotine\" \"nodemon -w src/views/home/Page.pug -x node build-pages.js index\" \"nodemon -w src/views/invalid/Page.pug -x node build-pages.js invalid\" \"nodemon -w src/views/meeting/Page.pug -x node build-pages.js meeting\" \"nodemon -w src/views/pretend/Page.pug -x node build-pages.js pretend\" \"nodemon -w src/views/sisyphus/Page.pug -x node build-pages.js sisyphus\" \"nodemon -w src/views/wrongest/Page.pug -x node build-pages.js wrongest\" \"nodemon -w src/views/stats/Page.pug -x node build-pages.js stats\"",
+    "watch:pages": "concurrently --names \"cameo,guillotine,home,invalid,meeting,pretend,sisyphus,wrongest,stats\" --prefix \"[{name}]\" --prefix-colors \"yellow,red,green,blue,magenta,cyan,white,gray,brightBlue\" -k \"nodemon --quiet -w src/views/cameo/Page.pug -x node build-pages.js cameo\" \"nodemon --quiet -w src/views/guillotine/Page.pug -x node build-pages.js guillotine\" \"nodemon --quiet -w src/views/home/Page.pug -x node build-pages.js index\" \"nodemon --quiet -w src/views/invalid/Page.pug -x node build-pages.js invalid\" \"nodemon --quiet -w src/views/meeting/Page.pug -x node build-pages.js meeting\" \"nodemon --quiet -w src/views/pretend/Page.pug -x node build-pages.js pretend\" \"nodemon --quiet -w src/views/sisyphus/Page.pug -x node build-pages.js sisyphus\" \"nodemon --quiet -w src/views/wrongest/Page.pug -x node build-pages.js wrongest\" \"nodemon --quiet -w src/views/stats/Page.pug -x node build-pages.js stats\"",
     "firebase:hydrate": "node scripts/firebase/cloneFirestore.js"
   },
   "dependencies": {

--- a/src/views/invalid/Invalid.scss
+++ b/src/views/invalid/Invalid.scss
@@ -1,4 +1,3 @@
-
 //GLOBALS, GET DEFAULTS
 @import "@/shared/scss/globals/_reset";
 @import "@/shared/scss/globals/_variables";
@@ -21,8 +20,12 @@
 @import "scss/_final";
 @import "scss/_game-over";
 
+// COMPONENTS
+@import "scss/toasts";
+
 // OTHER PAGES
 @import "scss/_article";
 
-
-input.uppercase { text-transform: uppercase; }
+input.uppercase {
+  text-transform: uppercase;
+}

--- a/src/views/invalid/Invalid.vue
+++ b/src/views/invalid/Invalid.vue
@@ -1073,19 +1073,70 @@
   const addBug = async () => {
     ui.addBugErrors = [];
     const bug = ui.addBug.toUpperCase();
-    let foundMatch = false;
-    round.challenge.possible.forEach(function (p, index) {
-      if (bug == p.toUpperCase()) {
-        foundMatch = true;
-      }
-    });
+    // Check for duplicate
+    const isDuplicate = round.bugs.some((b) => b.toUpperCase() === bug);
+    // Check for validity
+    const isValid = round.challenge.possible.some((p) => p.toUpperCase() === bug);
 
-    if (!foundMatch) {
-      ui.addBugErrors.push("Just so you know, " + bug + " wasn't a valid password");
+    // Toast message variants for invalid and duplicate bugs
+    const invalidBugMessages = [
+      `<p><code>{BUG}</code> is not recognized as a valid password in your current ruleset.</p>
+        <p>Our compliance robots have flagged this entry for further review, which will be ignored by the entire company, but you'll receive a number of emails about it.</p>`,
+      `<p><code>{BUG}</code> is not on the official password list for this challenge.</p>
+        <p>Please consult your company handbook, your supervisor, or the nearest sentient office plant for advice.</p>`,
+      `<p><code>{BUG}</code> would not have been a valid password. The system has notified HR, IT, and your 5th grade teacher. Please review the challenge requirements, try again, and remember: every mistake is logged for posterity.</p>`,
+      `<p><code>{BUG}</code> would not have been a valid password.</p><p>Double-check your ruleset, your spelling, and your life choices.</p>`,
+      `<p><code>{BUG}</code> would not have been a valid password.</p><p>Refer to the official documentation, or at least tell your supervisor that you did</p>`,
+      `<p><code>{BUG}</code> is not a recognized entry in your current ruleset.</p><p>For compliance, please use an approved password, or invent a new department to handle this situation.</p>`,
+      `<p><code>{BUG}</code> is not a valid password in this ruleset.</p><p>Check your spelling, your company rules, and your horoscope.</p>`,
+      `<p><code>{BUG}</code> is invalid for this round.</p><p>Hey, that's the name of the game! That's fun! :)</p>`,
+      `<p><code>{BUG}</code> has been flagged as "creative" but not "correct." We at BigCorp discourage creativity.</p>`,
+    ];
+
+    const duplicateBugMessages = [
+      `<p><code>{BUG}</code> has already generated a bug for this round.</p><p>BigCorp appreciates your continued vigilance. For compliance purposes, your duplicate bug will still be logged and you will be charged accordingly. Please consult the official bug tracker for further updates, or just move on with your life.</p>`,
+      `<p><code>{BUG}</code> is a duplicate bug entry.</p><p>You will still be charged for compliance, but not for originality.</p>`,
+      `<p><code>{BUG}</code> was already submitted for this round.</p><p>BigCorp thanks you for your attention to detail. Please check the bug tracker for updates, or just pretend this never happened.</p>`,
+      `<p><code>{BUG}</code> is a repeat entry.</p><p>Your duplicate will be processed, but not celebrated.</p>`,
+      `<p><code>{BUG}</code> is already in the system.</p><p>No need to report it again, but your duplicate will be processed, charged, and possibly used as an example in next week's training video.</p>`,
+      `<p><code>{BUG}</code> is already famous in our system. Further reports will be archived in the "Hall of Redundancy Hall."</p>`,
+      `<p>You already added <code>{BUG}</code>, but your enthusiasm is noted. Please consult the bug tracker for updates, or just go get a snack.</p>`,
+    ];
+
+    // Show invalid toast if not valid
+    if (!isValid && !isDuplicate) {
+      const msg = invalidBugMessages[Math.floor(Math.random() * invalidBugMessages.length)].replace("{BUG}", bug);
+      toast(
+        {
+          component: MyToast,
+          props: {
+            message: msg,
+          },
+        },
+        {
+          position: POSITION.BOTTOM_RIGHT,
+          type: "warning",
+          timeout: 6000,
+        },
+      );
     }
 
-    if (findInArray(round.bugs, bug)) {
-      ui.addBugErrors.push("You already added " + bug + ".");
+    // Show duplicate toast if duplicate
+    if (isDuplicate) {
+      const msg = duplicateBugMessages[Math.floor(Math.random() * duplicateBugMessages.length)].replace("{BUG}", bug);
+      toast(
+        {
+          component: MyToast,
+          props: {
+            message: msg,
+          },
+        },
+        {
+          position: POSITION.BOTTOM_RIGHT,
+          type: "warning",
+          timeout: 6000,
+        },
+      );
     }
 
     // Charge for adding the bug.

--- a/src/views/invalid/Invalid.vue
+++ b/src/views/invalid/Invalid.vue
@@ -1523,7 +1523,7 @@
             name: attempt,
             timesCrashed: 1,
             lastCrashed: serverTimestamp(),
-            timesCreated: 1,
+            timesCreated: 0,
           });
         }
       } catch (err) {

--- a/src/views/invalid/scss/_toasts.scss
+++ b/src/views/invalid/scss/_toasts.scss
@@ -1,0 +1,16 @@
+.Vue-Toastification__toast--warning {
+  color: $black;
+  .text-holder {
+    color: $black;
+    code {
+      font-size: 135%;
+      font-weight: 800;
+    }
+  }
+  .Vue-Toastification__close-button {
+    color: $black;
+  }
+  .Vue-Toastification__progress-bar {
+    background-color: $black;
+  }
+}


### PR DESCRIPTION
Couple things happening here:

1. Save bugs to Firebase when they are created.
2. Update crash log in Firebase when it happens
3. As a SysAdmin, if you create a bug that wouldn't have been a valid password, you get a toast about it.
4. And as a SysAdmin, if you create the same bug twice, you get a toast about that too.
5. ALSO, I prettied up the console when you run `npm run dev` cause it was ugly to look it. Now, the `watch:pages` command is REALLY gnarly looking, and I might clean that up some day, but I doubt it.