### PR TITLE
#244 Limit TMHP Players

### DIFF
--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -201,7 +201,7 @@
     game.roomCode = newRoomCode;
   }
 
-  import { gameName, timeToScore, badGuessPenalty, cardsPerPlayer, game, you, ui } from "./ts/_variables";
+  import { gameName, timeToScore, badGuessPenalty, cardsPerPlayer, game, you, ui, settings } from "./ts/_variables";
   const timer = ref(0); // Reactive reference to store timer value
   let interval = null; // Store the interval ID
 
@@ -232,6 +232,9 @@
   };
 
   const savePlayerInfo = async () => {
+    if (isRoomFull.value && !amISignedIn.value) {
+      return;
+    }
     you.name = you.nameInput;
     localStorage.save;
     you.jobTitle = you.jobTitleInput;
@@ -785,6 +788,10 @@
 
     // Clone and sort the players array by score in descending order
     return [...gamePlayers.value].sort((a, b) => b.score - a.score);
+  });
+
+  const isRoomFull = computed(() => {
+    return game.players.length >= settings.maxPlayers;
   });
 
   onMounted(() => {

--- a/src/views/meeting/pug/_players.pug
+++ b/src/views/meeting/pug/_players.pug
@@ -45,6 +45,10 @@
             li.unknown(v-else v-tippy="`No fucking idea what's going on here`") ???
         .player-score(v-if="game.isGameStarted") {{player.score}}
 
+  .room-capacity(v-if="!game.isGameStarted")
+    span(v-if="isRoomFull") The game is full. Let's play!
+    span(v-else) {{settings.maxPlayers - game.players.length}} more {{settings.maxPlayers - game.players.length === 1 ? 'person' : 'people'}} can play
+
   .end-meeting(v-if="game.isGameStarted && amITheHost")
     label Meeting Over?
     button(@click="endTheGame()") End the game.

--- a/src/views/meeting/pug/_pregame.pug
+++ b/src/views/meeting/pug/_pregame.pug
@@ -8,7 +8,12 @@
   template(v-if="game.roomData")
     .panel
       img.logo(src="/svg/games/thismeetinghaspoints.svg" alt="This Meeting Has Points")
-      form(@submit.prevent="savePlayerInfo()")
+
+      .room-full-notice(v-if="isRoomFull && !amISignedIn")
+        p This room is full.
+        p Maximum {{settings.maxPlayers}} players allowed.
+
+      form(v-else @submit.prevent="savePlayerInfo()")
         fieldset
           label.required(for="YourName") Your Name
           input#YourName(type="text" v-model="you.nameInput" placeholder="" autocomplete="on" data-1p-ignore)
@@ -19,12 +24,12 @@
           button(type="submit")
             span(v-if="amISignedIn") Change Profile
             span(v-else) Sign In
-      
+
       .button-holder(v-if="amITheHost && you.name")
-        template(v-if="game.players.length < 2")
-          span(v-tippy="{ content:'2 or more players required', delay: [100,450]}")
+        template(v-if="game.players.length < settings.minPlayers")
+          span(v-tippy="{ content: settings.minPlayers + ' or more players required', delay: [100,450]}")
             button.start-game(disabled) Start Game
-        template(v-if="game.players.length > 1")
+        template(v-if="game.players.length >= settings.minPlayers")
           .start-game-wrapper
             label When all players are ready...
             button.start-game(@click="shuffleUpAndDeal()") Start The Game

--- a/src/views/meeting/scss/_players.scss
+++ b/src/views/meeting/scss/_players.scss
@@ -1,6 +1,9 @@
 .card-players {
   background: #040404;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   ul.players {
     display: grid;
     gap: 20px;
@@ -66,6 +69,14 @@
         background-color: $blue;
       }
     }
+  }
+  .room-capacity {
+    padding: 20px;
+    font-family: $sans-serif;
+    font-size: 0.75rem;
+    color: rgba($yellow, 0.85);
+    font-weight: 725;
+    text-align: center;
   }
 
   &.for-host {

--- a/src/views/meeting/ts/_variables.ts
+++ b/src/views/meeting/ts/_variables.ts
@@ -37,6 +37,7 @@ export const ui = reactive({
 });
 
 export const settings = reactive({
-  // maxPlayers added by #244
+  minPlayers: 2,
+  maxPlayers: 9,
   // isEventActive, eventCardsPerGame added by #246
 });


### PR DESCRIPTION
## Summary

- Adds `settings.maxPlayers` (9) and `settings.minPlayers` (2) constants to the `settings` reactive object in `_variables.ts`
- Gates `savePlayerInfo()` so players can't join a full room; shows a "This room is full" notice in the pregame panel in place of the sign-in form
- Shows remaining capacity ("X more people can play" / "The game is full. Let's play!") in the player sidebar, visible to all players during the pregame
- Host's Start Game button now uses `settings.minPlayers` rather than a hardcoded value

## Test plan

- [ ] Join a room as the 10th player — should see "This room is full" instead of the sign-in form, and be blocked from joining
- [ ] With fewer than 9 players, sidebar shows correct remaining count with correct singular/plural
- [ ] When the 9th player joins, sidebar changes to "The game is full. Let's play!"
- [ ] Start Game button is disabled with fewer than 2 players and enabled at 2+
- [ ] Existing deal, score, and steal logic is unaffected