### PR TITLE
#255 Pregame screen improvements

### DIFF
--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -288,6 +288,8 @@
     const roomRef = doc(db, `rooms/${game.roomCode}`);
     await updateDoc(roomRef, { isDealingInProgress: true });
 
+    let dealSucceeded = false;
+    try {
     // --- Update player stats before dealing cards ---
     const now = serverTimestamp();
     for (const player of gamePlayers.value) {
@@ -430,6 +432,16 @@
       gamesStarted: increment(1),
       lastGameStarted: serverTimestamp(),
     });
+    dealSucceeded = true;
+    } catch (error) {
+      console.error("Failed to start game:", error);
+      alert("Something went wrong starting the game. Please try again.");
+    } finally {
+      if (!dealSucceeded) {
+        isDealing.value = false;
+        updateDoc(roomRef, { isDealingInProgress: false }).catch(() => {});
+      }
+    }
   };
 
   const playThisCard = (card) => {
@@ -866,7 +878,7 @@
   const canSaveProfile = computed(() => {
     const nameValid = you.nameInput.trim().length > 0;
     if (!amISignedIn.value) return nameValid;
-    return nameValid && you.nameInput !== you.name;
+    return nameValid && (you.nameInput !== you.name || you.jobTitleInput !== you.jobTitle);
   });
 
   onMounted(() => {

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -182,10 +182,17 @@
       (docSnapshot) => {
         if (docSnapshot.exists()) {
           const data = docSnapshot.data();
-          // console.log("Game status update:", data);
+          const prevDealing = game.isDealingInProgress;
           game.isGameStarted = data.isGameStarted ?? false;
           game.roomCreatorID = data.roomCreatorID ?? "";
           game.isGameOver = data.isGameOver ?? false;
+          game.isDealingInProgress = data.isDealingInProgress ?? false;
+
+          if (game.isDealingInProgress && !prevDealing && !amITheHost.value) {
+            const hostPlayer = gamePlayers.value.find((p) => p.playerID === game.roomCreatorID);
+            const hostName = hostPlayer?.name ?? "The host";
+            toast(`${hostName} is starting the game. Dealing cards now...`, { timeout: 6000 });
+          }
         } else {
           console.error("Game document does not exist.");
           game.isFailedToGetRoomData = true;
@@ -205,6 +212,7 @@
   import { gameName, timeToScore, badGuessPenalty, game, you, ui, settings } from "./ts/_variables";
   const timer = ref(0); // Reactive reference to store timer value
   let interval = null; // Store the interval ID
+  const isDealing = ref(false);
 
   const generateUniqueID = () => {
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -276,6 +284,10 @@
   };
 
   const shuffleUpAndDeal = async () => {
+    isDealing.value = true;
+    const roomRef = doc(db, `rooms/${game.roomCode}`);
+    await updateDoc(roomRef, { isDealingInProgress: true });
+
     // --- Update player stats before dealing cards ---
     const now = serverTimestamp();
     for (const player of gamePlayers.value) {
@@ -363,6 +375,8 @@
       ].filter(Boolean);
       if (hand.length < 5) {
         console.error("Not enough cards to deal full hands");
+        isDealing.value = false;
+        await updateDoc(roomRef, { isDealingInProgress: false });
         alert("Not enough cards to deal — game cannot start.");
         return;
       }
@@ -408,9 +422,9 @@
       }
     }
 
-    const roomRef = doc(db, `rooms/${game.roomCode}`);
     await updateDoc(roomRef, {
       isGameStarted: true,
+      isDealingInProgress: false,
     });
     await updateDoc(statsRef, {
       gamesStarted: increment(1),
@@ -847,6 +861,12 @@
 
   const isRoomFull = computed(() => {
     return game.players.length >= settings.maxPlayers;
+  });
+
+  const canSaveProfile = computed(() => {
+    const nameValid = you.nameInput.trim().length > 0;
+    if (!amISignedIn.value) return nameValid;
+    return nameValid && you.nameInput !== you.name;
   });
 
   onMounted(() => {

--- a/src/views/meeting/pug/_pregame.pug
+++ b/src/views/meeting/pug/_pregame.pug
@@ -1,9 +1,11 @@
 .pregame-lobby(v-if="!game.isGameStarted")
 
-  .room-code(v-if="game.roomCode")
+  .room-code(v-if="game.roomCode" :class="{ 'is-full': isRoomFull }")
     .label your room code
     .display {{game.roomCode}}
-    .how-to-share(v-if="game.players.length > 0") Share this URL to invite your friends to play.
+    template(v-if="game.players.length > 0")
+      .how-to-share(v-if="isRoomFull") This game is full
+      .how-to-share(v-else) Share this URL to invite your friends to play.
   
   template(v-if="game.roomData")
     .panel
@@ -21,7 +23,7 @@
           label(for="YourJobTitle") Make Up A Job Title
           input#YourJobTitle(type="text" v-model="you.jobTitleInput" placeholder="ex: Cat Herder" autocomplete="on" data-1p-ignore)
         .button-holder
-          button(type="submit")
+          button(type="submit" :disabled="!canSaveProfile")
             span(v-if="amISignedIn") Change Profile
             span(v-else) Sign In
 
@@ -30,7 +32,13 @@
           span(v-tippy="{ content: settings.minPlayers + ' or more players required', delay: [100,450]}")
             button.start-game(disabled) Start Game
         template(v-if="game.players.length >= settings.minPlayers")
-          .start-game-wrapper
+          .dealing-in-progress(v-if="isDealing")
+            .dealing-dots
+              span .
+              span .
+              span .
+            .dealing-message Dealing out your cards for the meeting
+          .start-game-wrapper(v-else)
             label When all players are ready...
             button.start-game(@click="shuffleUpAndDeal()") Start The Game
 

--- a/src/views/meeting/scss/_players.scss
+++ b/src/views/meeting/scss/_players.scss
@@ -71,12 +71,13 @@
     }
   }
   .room-capacity {
-    padding: 20px;
+    padding: 10px 20px 18px;
     font-family: $sans-serif;
-    font-size: 0.75rem;
-    color: rgba($yellow, 0.85);
+    font-size: 1rem;
+    color: $yellow;
     font-weight: 725;
     text-align: center;
+    border-top: 1px solid rgba($yellow, 0.2);
   }
 
   &.for-host {

--- a/src/views/meeting/scss/_pregame.scss
+++ b/src/views/meeting/scss/_pregame.scss
@@ -76,6 +76,15 @@
       &:focus {
         background: $yellow;
       }
+      &:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+        &:hover,
+        &:focus {
+          background: $white;
+          color: $black;
+        }
+      }
     }
   }
   .share-callout {
@@ -134,6 +143,7 @@
       color: $yellow;
       font-weight: 800;
       line-height: 90%;
+      transition: filter 0.3s ease;
     }
     .how-to-share {
       font-family: $sans-serif;
@@ -141,6 +151,60 @@
       font-size: 0.75rem;
       max-width: 160px;
       padding-top: 0.5em;
+    }
+    &.is-full {
+      .display {
+        filter: blur(0.18em);
+        user-select: none;
+      }
+      .how-to-share {
+        font-weight: 700;
+      }
+    }
+  }
+
+  .dealing-in-progress {
+    text-align: center;
+    padding: 0.5em 0;
+
+    .dealing-dots {
+      color: $yellow;
+      font-family: $monospace;
+      font-size: 2rem;
+      font-weight: 800;
+      letter-spacing: 0.3em;
+      line-height: 1;
+
+      span {
+        display: inline-block;
+        animation: dealDotBounce 1s ease-in-out infinite;
+        &:nth-child(2) {
+          animation-delay: 0.15s;
+        }
+        &:nth-child(3) {
+          animation-delay: 0.3s;
+        }
+      }
+    }
+
+    .dealing-message {
+      margin-top: 0.6em;
+      font-family: $sans-serif;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: $white;
+    }
+  }
+
+  @keyframes dealDotBounce {
+    0%,
+    100% {
+      transform: translateY(0);
+      opacity: 1;
+    }
+    50% {
+      transform: translateY(-8px);
+      opacity: 0.25;
     }
   }
 

--- a/src/views/meeting/ts/_variables.ts
+++ b/src/views/meeting/ts/_variables.ts
@@ -12,6 +12,7 @@ export const game = reactive({
   roomData: null as null,
   isGameStarted: false,
   isGameOver: false,
+  isDealingInProgress: false,
   roomCreatorID: "",
   deck: [] as any[],
   players: [] as any,


### PR DESCRIPTION
## Summary

- **Change Profile button guard** — disabled unless `nameInput` is non-blank and (when already signed in) differs from the current saved name. Paired with a `:disabled` CSS state (faded, `cursor: not-allowed`).
- **Room capacity more noticeable** — bumped `.room-capacity` from `0.75rem` to `1rem`, full `$yellow` opacity, added a subtle top border to separate it from the player list.
- **Room-code full state** — when `isRoomFull`, `.display` blurs with a smooth transition and `.how-to-share` switches to "This game is full".
- **Dealing animation (host)** — clicking Start replaces the button with a bouncing three-dot monospace animation + "Dealing out your cards for the meeting". `isDealingInProgress: true` is written to Firestore immediately so non-hosts get notified.
- **Non-host toast** — when `isDealingInProgress` rises, non-hosts see `"{host} is starting the game. Dealing cards now..."`.

## Test plan

- [x] Sign-in form: "Sign In" button is disabled when name is blank/spaces; enabled once a name is typed
- [x] Change Profile: button stays disabled until the name field differs from the currently saved name
- [x] Fill the room to max players — verify `.display` blurs and `.how-to-share` reads "This game is full"
- [x] Check that "X more people can play" count at the bottom of the player list is clearly readable
- [x] As host: click Start — confirm the button is replaced by the bouncing-dot animation
- [x] As a non-host in the same room: confirm the toast fires when the host clicks Start