### PR TITLE
#241 Refactor Court.vue — extract composables

### DIFF
--- a/src/views/court/Court.vue
+++ b/src/views/court/Court.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { reactive, computed, onMounted } from "vue";
+  import { reactive, onMounted } from "vue";
   import { useFirestore } from "vuefire";
   import { useToast, POSITION } from "vue-toastification";
   import TacticToast from "./components/TacticToast.vue";
@@ -9,14 +9,12 @@
     historicalJustices,
     fictionalJustices,
     celebrityJustices,
-    warrenJustices,
-    lochnerJustices,
     presetBenchConfigs,
   } from "./ts/justices";
   import { cases as allCases, casesHistorical, casesFictional } from "./ts/_cases";
   import { tactics as allTactics } from "./ts/_tactics";
-  import type { Justice, Case, Tactic, CourtGameState, CampaignState, President, StanceOpinion, StanceType } from "./ts/_types";
-  import { resolveEffect, partiesAligned, partiesOpposed, leftParties, rightParties } from "./ts/_tacticEffects";
+  import type { Justice, Case, Tactic, CourtGameState, CampaignState, President, StanceType } from "./ts/_types";
+  import { resolveEffect, partiesAligned, partiesOpposed } from "./ts/_tacticEffects";
   import type { EffectOutcome } from "./ts/_tacticEffects";
   import { settings, gameSettings, uiSettings, difficultySettings, cheatsActive } from "./ts/_settings";
   import { campaignSetups } from "./ts/_campaigns";
@@ -33,6 +31,9 @@
     getWinningSide,
     type CourtOutcome,
   } from "./ts/_statsHelpers";
+  import { useCourtComputeds } from "./ts/_useCourtComputeds";
+  import { useCourtHelpers, getKeyStats, justiceTypeLabel, sideStanceTags, targetLabel, voteLabel, justiceImageUrl, presidentImageUrl, justiceHints } from "./ts/_useCourtHelpers";
+  import { useCourtTurns } from "./ts/_useCourtTurns";
 
   // ── Game settings ──────────────────────────────────────────
 
@@ -67,18 +68,16 @@
     courtMode: null as CourtMode | null,
     courtReportVisible: false,
     opponentThinking: false,
-    opponentHighlightedCardId: null as number | null, // card the opponent appears to be browsing
-    detailJustice: null as Justice | null, // justice whose detail modal is open
-    detailPresident: null as President | null, // president whose detail modal is open
-    targetingChoice: null as Justice | null, // justice clicked while a tactic is selected
-    previewPresetId: null as string | null, // preset selected in dropdown, awaiting preview confirmation
-    // Campaign UI state
+    opponentHighlightedCardId: null as number | null,
+    detailJustice: null as Justice | null,
+    detailPresident: null as President | null,
+    targetingChoice: null as Justice | null,
+    previewPresetId: null as string | null,
     isCampaignMode: false,
     campaignSetupId: null as number | null,
     rewardTargetJustice: null as number | null,
     rewardEligibleTarget: null as number | null,
     activatingRewardId: null as string | null,
-    // Cheat UI state
     cheatTargetMode: null as null | "love" | "hate",
   });
 
@@ -88,26 +87,21 @@
     playerSide: null,
     chiefJusticeId: null,
     chiefJusticeHardened: false,
-    // Card pools
     deck: [],
     discardPile: [],
     playbook: [],
     claimedCards: [],
-    // Turn state
     currentTurn: "player",
     round: 1,
     totalRounds: gameSettings.numberOfRounds,
-    // Targeting
     selectedTacticId: null,
     claimingMode: false,
     claimedSelections: [],
-    // Justice state
     leanings: {},
     susceptibilityMods: {},
     playerShields: [],
     opponentShields: [],
     recusedJustices: [],
-    // Trial-scoped state for new cards
     nappingJustices: {},
     yogaJustices: {},
     draggedJustices: [],
@@ -117,18 +111,15 @@
     multiTargetMode: false,
     multiTargetSelections: [],
     multiTargetTacticId: null,
-    // Campaign trial-scoped
     makeChiefPlayedThisTrial: false,
     suggestRetirementTargets: [],
     keepCrownActivated: false,
-    // Reframe The Debate stance selection
     reframeStanceMode: false,
     reframeStanceChoices: [] as StanceType[],
     reframeStanceTacticId: null as number | null,
     reframeStanceSelection: null as StanceType | null,
   });
 
-  // ── Campaign state — null when not in campaign mode ───────────
   const campaign = reactive<{ data: CampaignState | null }>({ data: null });
 
   const courtReport = reactive({
@@ -145,11 +136,9 @@
   const caseHistory = reactive<
     Array<{
       caseName: string;
-      votes: Record<number, boolean>; // justice.id → true = voted for player
+      votes: Record<number, boolean>;
     }>
   >([]);
-
-  // tacticFeedback replaced by Vue-Toastification (see applyTactic)
 
   // ─── Firestore Stats ───────────────────────────────────────
 
@@ -172,8 +161,6 @@
     await courtStats.writeTacticStats({
       tacticName: tactic.name,
       actor,
-      // Normalize netShift to absolute value so averageNetShiftPerPlay measures card power,
-      // not directionality (opponent plays yield negative shifts in the player-reference frame).
       metrics: { ...metrics, netShift: Math.abs(metrics.netShift) },
     });
   }
@@ -273,7 +260,6 @@
   }
 
   // ─── Helpers ─────────────────────────────────────────────────
-  // partiesAligned / partiesOpposed are imported from _tacticEffects.ts
 
   function shuffle<T>(array: T[]): T[] {
     const arr = [...array];
@@ -292,7 +278,6 @@
 
     let stanceScore = 0;
 
-    // Tier 1: Justice's own stances vs. case stances
     if (justice.stances && playerSideStances) {
       for (const { topic, position } of justice.stances) {
         const casePosition = playerSideStances[topic];
@@ -307,7 +292,6 @@
       }
     }
 
-    // Tier 2: Nominating president stances vs. case stances, scaled by justice's partyLoyalty
     const president = justice.nominatedBy;
     if (president?.stances && playerSideStances) {
       const loyaltyFactor = justice.stats.partyLoyalty / 10;
@@ -319,15 +303,12 @@
       }
     }
 
-    // Tier 3: Party alignment fallback
     const playerParty = game.playerSide === "prosecution" ? game.currentCase.prosecution.favoredBy : game.currentCase.defendant.favoredBy;
     const justiceParty = justice.nominatedBy?.party;
     let partyScore = 0;
     if (partiesAligned(playerParty, justiceParty)) partyScore = Math.ceil(justice.stats.partyLoyalty * 2.5);
     if (partiesOpposed(playerParty, justiceParty)) partyScore = -Math.ceil(justice.stats.partyLoyalty * 2.5);
 
-    // Tier 4: Deterministic per-case variance to avoid samey opening leanings.
-    // Seeded by case + justice so a given case opens consistently, not with reroll noise.
     const clampedLoyalty = Math.max(0, Math.min(10, justice.stats.partyLoyalty));
     const loyaltyVarianceFactor = 0.4 + (10 - clampedLoyalty) * 0.1;
     const varianceRange = Math.max(0, difficultySettings.startingVariance) * loyaltyVarianceFactor;
@@ -341,7 +322,6 @@
 
   // ─── Deck Management ─────────────────────────────────────────
 
-  /** Build a tactic deck, respecting cheat ordering when cheats are active. */
   function buildCheatDeck(pool: Tactic[]): Tactic[] {
     if (!cheatsActive || settings.cheats.shuffleTactics) return shuffle(pool);
     const ordered = settings.cheats.tacticOrder.map((id) => pool.find((t) => t.id === id)).filter((t): t is Tactic => !!t);
@@ -358,12 +338,9 @@
     return game.deck.shift() ?? null;
   }
 
-  // Remove a card from the playbook, add it to discard, draw a replacement.
-  // Draw BEFORE pushing to discard so reshuffle doesn't immediately re-draw the same card.
   function removeFromPlaybook(tactic: Tactic): void {
     game.playbook = game.playbook.filter((t) => t.id !== tactic.id);
     game.discardPile.push(tactic);
-    // Delay draw so the leave animation completes before the enter animation starts.
     setTimeout(() => {
       const drawn = drawCard();
       if (drawn) game.playbook.push(drawn);
@@ -383,6 +360,75 @@
   function markPlayedCurrentCourt(): void {
     localStorage.setItem("hasPlayedCurrentCourt", "true");
   }
+
+  // ─── Lemon Moment ────────────────────────────────────────────
+
+  function triggerLemonMomentIfDue(): void {
+    const midRound = Math.ceil(gameSettings.numberOfRounds / 2);
+    if (game.round < midRound || byLemonToastShown) return;
+    byLemonToastShown = true;
+    if (!byLemonJinglePlayed) {
+      byLemonJinglePlayed = true;
+      const jingle = new Audio("/audio/bylemon.mp3");
+      jingle.volume = 0.6;
+      void jingle.play();
+    }
+    toast(
+      { component: LemonToast },
+      {
+        toastClassName: "site-by-lemon",
+        icon: false,
+        timeout: 6000,
+        showCloseButtonOnHover: false,
+        closeButtonClassName: "close-toast",
+      },
+    );
+  }
+
+  // ─── Turn Management (composable) ────────────────────────────
+  // applyTactic is a function declaration and is hoisted, so the closure below resolves correctly.
+
+  const { endPlayerTurn, endOpponentTurn, getEligibleMultiTargetJustices } = useCourtTurns(
+    game,
+    campaign,
+    ui,
+    {
+      trackTrialVerdictStats,
+      applyTactic: (t, j, a) => applyTactic(t, j, a),
+      shuffle,
+      triggerLemonMomentIfDue,
+    },
+  );
+
+  // ─── Computed Values (composable) ────────────────────────────
+
+  const {
+    allJustices,
+    historicalPresets,
+    fictionalPresets,
+    sortedBench,
+    hasStrongAlly,
+    reframeStanceStats,
+    benchOverview,
+    verdict,
+    tallyDisplay,
+    tallyClass,
+    tallyTooltip,
+    reportByRound,
+    verdictSections,
+    verdictRuledFor,
+    verdictWinningArgument,
+    verdictScoreDisplay,
+    justiceTargetings,
+    chiefJustice,
+    benchLabel,
+    previewPreset,
+    previewPresetChief,
+  } = useCourtComputeds({ game, ui, courtReport });
+
+  // ─── UI Helpers (composable) ─────────────────────────────────
+
+  const { voteMeterStyle, verdictJusticeBarStyle, justiceVoteHistory } = useCourtHelpers(game, caseHistory);
 
   // ─── Game Management ─────────────────────────────────────────
 
@@ -405,20 +451,7 @@
     ui.phase = "courtSelect";
   }
 
-  const allJustices = computed(() => [
-    ...currentJustices,
-    ...historicalJustices,
-    ...fictionalJustices,
-    ...celebrityJustices,
-    ...warrenJustices,
-    ...lochnerJustices,
-  ]);
-
-  const historicalPresets = computed(() => presetBenchConfigs.filter((b) => ["current", "warren-court", "lochner-era"].includes(b.id)));
-  const fictionalPresets = computed(() => presetBenchConfigs.filter((b) => !["current", "warren-court", "lochner-era"].includes(b.id)));
-
   function dealGame(): void {
-    // Save this game's justice votes to case history before resetting
     if (game.currentCase && game.bench.length && (ui.phase === "playing" || ui.phase === "verdict")) {
       const votes: Record<number, boolean> = {};
       game.bench.forEach((j) => {
@@ -427,7 +460,6 @@
       caseHistory.push({ caseName: game.currentCase.name, votes });
     }
 
-    // Build justice pool + assign chief justice based on selected mode
     const mode = ui.courtMode ?? "current";
     let pool: Justice[];
     let chiefId: number | null = null;
@@ -438,8 +470,8 @@
       pool = presetConfig.justiceIds.map((id) => allJustices.value.find((j) => j.id === id)).filter((j): j is Justice => !!j);
       chiefId = presetConfig.chiefJusticeId;
     } else if (mode === "current") {
-      pool = [...currentJustices]; // always use all 9 current justices
-      chiefId = 1; // John Roberts is always Chief in Current mode
+      pool = [...currentJustices];
+      chiefId = 1;
     } else if (mode === "historical") {
       pool = shuffle([...currentJustices, ...historicalJustices]).slice(0, 9);
       chiefId = pool[Math.floor(Math.random() * pool.length)].id;
@@ -447,7 +479,6 @@
       pool = shuffle([...fictionalJustices, ...celebrityJustices]).slice(0, 9);
       chiefId = pool[Math.floor(Math.random() * pool.length)].id;
     } else {
-      // chaos: any justice
       pool = shuffle([...allJustices.value]).slice(0, 9);
       chiefId = pool[Math.floor(Math.random() * pool.length)].id;
     }
@@ -455,7 +486,7 @@
     game.bench = pool;
     game.chiefJusticeId = chiefId;
     game.chiefJusticeHardened = hardened;
-    // Select a case from the appropriate pool based on court mode
+
     let casePool: typeof allCases;
     if (presetConfig) {
       casePool = presetConfig.casePool === "historical" ? casesHistorical : presetConfig.casePool === "fictional" ? casesFictional : allCases;
@@ -464,7 +495,6 @@
     } else if (mode === "fantasy") {
       casePool = casesFictional;
     } else {
-      // chaos: any case
       casePool = allCases;
     }
     game.currentCase = casePool[Math.floor(Math.random() * casePool.length)];
@@ -515,7 +545,6 @@
   }
 
   function startArguments(): void {
-    // Campaign-only tactics only enter the deck in campaign mode
     const hasTrumpNominee = game.bench.some((j) => j.nominatedBy?.name === "Donald Trump");
     let deckPool = ui.isCampaignMode ? [...allTactics] : allTactics.filter((t) => !t.campaignOnly);
     if (!hasTrumpNominee) deckPool = deckPool.filter((t) => !t.requiresTrumpNominee);
@@ -536,7 +565,6 @@
     }
   }
 
-  /** Quick Play only: replay the same case with the same justices (reset leanings + deal fresh cards). */
   function retrySameCase(): void {
     const hasTrumpNominee = game.bench.some((j) => j.nominatedBy?.name === "Donald Trump");
     let deckPool = allTactics.filter((t) => !t.campaignOnly);
@@ -575,18 +603,9 @@
     game.multiTargetTacticId = null;
   }
 
-  function getEligibleMultiTargetJustices(tactic: Tactic | null): Justice[] {
-    if (!tactic) return [];
-    if (tactic.effectType === "swap-clerks") {
-      return game.bench.filter((justice) => !(justice.id in game.nappingJustices) && !game.recusedJustices.includes(justice.id));
-    }
-    return [];
-  }
-
   function selectTactic(tacticId: number): void {
     if (game.currentTurn !== "player" || ui.opponentThinking) return;
 
-    // In claiming mode: player is choosing which 2 docket cards to claim
     if (game.claimingMode) {
       const idx = game.claimedSelections.indexOf(tacticId);
       if (idx !== -1) {
@@ -598,7 +617,6 @@
       return;
     }
 
-    // Deselect multi-target mode if player clicks the active card again
     if (game.multiTargetMode && game.multiTargetTacticId === tacticId) {
       clearMultiTargetMode();
       return;
@@ -626,20 +644,17 @@
     ) {
       applyTactic(tactic, null, "player");
     } else if (tactic.effectType === "claim-two") {
-      if (game.claimedCards.length > 0) return; // already have dibs
-      // Remove dibs card WITHOUT drawing a replacement yet; player picks from the 4 remaining
+      if (game.claimedCards.length > 0) return;
       game.playbook = game.playbook.filter((t) => t.id !== tactic.id);
       game.discardPile.push(tactic);
       game.claimingMode = true;
       game.claimedSelections = [];
     } else if (tactic.effectType === "betray-friend") {
-      // Disabled unless at least one justice is Strongly For (leaning >= 60)
-      const hasStrongAlly = game.bench.some((j) => (game.leanings[j.id] ?? 0) >= 60);
-      if (!hasStrongAlly) return;
+      const hasStrongAllyNow = game.bench.some((j) => (game.leanings[j.id] ?? 0) >= 60);
+      if (!hasStrongAllyNow) return;
       game.selectedTacticId = game.selectedTacticId === tacticId ? null : tacticId;
     } else if (tactic.effectType === "swap-clerks") {
-      // Enter multi-target mode: player must click 2 justices
-      if (game.multiTargetMode) return; // already in multi-target mode for another card
+      if (game.multiTargetMode) return;
       const eligibleMultiTargetJustices = getEligibleMultiTargetJustices(tactic);
       if (eligibleMultiTargetJustices.length < 2) return;
       game.selectedTacticId = null;
@@ -656,7 +671,6 @@
       game.reframeStanceTacticId = tactic.id;
       game.reframeStanceMode = true;
     } else {
-      // sway-one, shield, encourage-nap, suggest-yoga, justice-cocktails, invite-church, recuse, make-chief, suggest-retirement, drag-them, catch-phone, plant-story, whisper-campaign: select then click a justice
       game.selectedTacticId = game.selectedTacticId === tacticId ? null : tacticId;
     }
   }
@@ -665,7 +679,6 @@
     const claimed = game.playbook.filter((t) => game.claimedSelections.includes(t.id));
     game.playbook = game.playbook.filter((t) => !game.claimedSelections.includes(t.id));
     game.claimedCards.push(...claimed);
-    // Draw 1 card after a delay so the claim-move animation completes first.
     setTimeout(() => {
       const drawn = drawCard();
       if (drawn) game.playbook.push(drawn);
@@ -687,15 +700,12 @@
     if (ui.phase !== "playing" || game.selectedTacticId === null || game.currentTurn !== "player") return;
     const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.selectedTacticId);
     if (!tactic) return;
-    // Shield must target an ally (leaning > 0)
     if (tactic.effectType === "shield" && (game.leanings[justice.id] ?? 0) <= 0) return;
-    // Betray-friend must target a STRONGLY FOR justice (leaning >= 60)
     if (tactic.effectType === "betray-friend" && (game.leanings[justice.id] ?? 0) < 60) return;
     applyTactic(tactic, justice, "player");
     game.selectedTacticId = null;
   }
 
-  // Called when player confirms targeting from the choice popup
   function confirmTarget(): void {
     if (!ui.targetingChoice) return;
     const justice = ui.targetingChoice;
@@ -703,7 +713,6 @@
     selectJustice(justice);
   }
 
-  // Called when player picks a stance topic in Reframe The Debate
   function confirmReframeStance(stance: StanceType): void {
     if (!game.reframeStanceTacticId) return;
     const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.reframeStanceTacticId);
@@ -718,14 +727,12 @@
     game.reframeStanceChoices = [];
   }
 
-  // Unified justice click handler: opens detail view or targeting choice depending on context
   function handleJusticeClick(justice: Justice): void {
     function openDetail(): void {
       ui.detailJustice = justice;
       if (settings.features.usePokeVoice) playJusticeVoice(justice, "neutral");
     }
 
-    // Cheat: MAKE LOVE / MAKE HATE targeting mode
     if (cheatsActive && ui.cheatTargetMode && ui.phase === "playing") {
       game.leanings[justice.id] = ui.cheatTargetMode === "love" ? 100 : -100;
       ui.cheatTargetMode = null;
@@ -738,7 +745,6 @@
     }
     if (ui.phase !== "playing" || ui.opponentThinking) return;
 
-    // Multi-target mode (swap-clerks): collect 2 justice ids then fire
     if (game.multiTargetMode && game.currentTurn === "player") {
       const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.multiTargetTacticId) ?? null;
       const eligibleJusticeIds = new Set(getEligibleMultiTargetJustices(tactic).map((targetJustice) => targetJustice.id));
@@ -765,7 +771,6 @@
 
     if (game.selectedTacticId !== null && game.currentTurn === "player") {
       const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.selectedTacticId);
-      // Invalid target conditions → open detail instead
       if (!tactic) {
         openDetail();
         return;
@@ -785,7 +790,6 @@
   }
 
   // ─── Apply Tactic ────────────────────────────────────────────
-  // All effect logic lives in _tacticEffects.ts; this function is a thin dispatcher.
 
   function applyTactic(tactic: Tactic, targetJustice: Justice | null, actor: TurnActor): void {
     const outcome: EffectOutcome = resolveEffect(game, tactic, targetJustice, actor, { drawCard, removeFromPlaybook });
@@ -851,8 +855,6 @@
       endOpponentTurn();
     }
 
-    // Purge the Record clears all 5 cards before drawing replacements.
-    // Stagger the draws so each new card enters one at a time after the leave animation.
     if (outcome.pendingRedraws) {
       const count = outcome.pendingRedraws;
       for (let i = 0; i < count; i++) {
@@ -867,329 +869,8 @@
     }
   }
 
-  // ─── Lemon Moment ────────────────────────────────────────────
+  // ─── Campaign Composable ──────────────────────────────────────
 
-  function triggerLemonMomentIfDue(): void {
-    const midRound = Math.ceil(gameSettings.numberOfRounds / 2);
-    if (game.round < midRound || byLemonToastShown) return;
-    byLemonToastShown = true;
-    if (!byLemonJinglePlayed) {
-      byLemonJinglePlayed = true;
-      const jingle = new Audio("/audio/bylemon.mp3");
-      jingle.volume = 0.6;
-      void jingle.play();
-    }
-    toast(
-      { component: LemonToast },
-      {
-        toastClassName: "site-by-lemon",
-        icon: false,
-        timeout: 6000,
-        showCloseButtonOnHover: false,
-        closeButtonClassName: "close-toast",
-      },
-    );
-  }
-
-  // ─── Turn Management ─────────────────────────────────────────
-
-  function endPlayerTurn(): void {
-    // Double Tap reward card: player gets an extra action this turn
-    if (campaign.data?.doubleTapActive) {
-      campaign.data.doubleTapActive = false;
-      return; // stay on player's turn
-    }
-
-    // Mess With The Calendar: skip opponent's turn and the entire next round
-    if (game.skipNextRound) {
-      delete game.skipNextRound;
-      game.round += 2; // Skip opponent's current turn + entire next round
-      game.currentTurn = "player";
-      triggerLemonMomentIfDue();
-
-      if (game.round > gameSettings.numberOfRounds) {
-        void trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
-        setTimeout(() => {
-          ui.phase = "verdict";
-        }, 1500);
-      }
-      return;
-    }
-
-    // Shields are consumed on contact (in resolveEffect), not cleared wholesale here
-    game.currentTurn = "opponent";
-    ui.opponentThinking = true;
-
-    // Simulate opponent browsing the Playbook for 4-6 seconds
-    const thinkTime = 4000 + Math.random() * 2000;
-    const browseInterval = 650;
-    let elapsed = 0;
-
-    const browseTimer = setInterval(() => {
-      elapsed += browseInterval;
-      const available = game.playbook.filter((t) => t.effectType !== "claim-two");
-      if (available.length) {
-        const pick = available[Math.floor(Math.random() * available.length)];
-        ui.opponentHighlightedCardId = pick.id;
-      }
-      if (elapsed >= thinkTime) {
-        clearInterval(browseTimer);
-        ui.opponentHighlightedCardId = null;
-        setTimeout(() => playOpponentTurn(), 200);
-      }
-    }, browseInterval);
-  }
-
-  function playOpponentTurn(): void {
-    // Opponent draws only from the playbook (not claimed cards); skip campaign-only tactics
-    const available = game.playbook.filter((t) => t.effectType !== "claim-two" && t.effectType !== "suggest-retirement" && t.effectType !== "keep-crown");
-    if (!available.length) {
-      endOpponentTurn();
-      return;
-    }
-    const tactic = available[Math.floor(Math.random() * available.length)];
-
-    if (
-      tactic.effectType === "sway-all" ||
-      tactic.effectType === "request-amicus" ||
-      tactic.effectType === "susceptibility" ||
-      tactic.effectType === "discard-all" ||
-      tactic.effectType === "recite-dissent" ||
-      tactic.effectType === "insult-chief" ||
-      tactic.effectType === "presidential-call" ||
-      tactic.effectType === "saint-patricks" ||
-      tactic.effectType === "lemon-test" ||
-      tactic.effectType === "fog-machine" ||
-      tactic.effectType === "alien-abduction" ||
-      tactic.effectType === "mess-calendar" ||
-      tactic.effectType === "international-law" ||
-      tactic.effectType === "gift-boxes"
-    ) {
-      applyTactic(tactic, null, "opponent");
-      return;
-    }
-
-    // New single-target utility cards: target the most favorable-to-player justice
-    if (
-      tactic.effectType === "encourage-nap" ||
-      tactic.effectType === "suggest-yoga" ||
-      tactic.effectType === "justice-cocktails" ||
-      tactic.effectType === "catch-phone" ||
-      tactic.effectType === "plant-story" ||
-      tactic.effectType === "whisper-campaign"
-    ) {
-      const unblocked = game.bench.filter((j) => !(j.id in game.nappingJustices) && !(j.id in game.yogaJustices) && !game.playerShields.includes(j.id));
-      const target = unblocked.sort((a, b) => (game.leanings[b.id] ?? 0) - (game.leanings[a.id] ?? 0))[0];
-      if (!target) {
-        endOpponentTurn();
-        return;
-      }
-      applyTactic(tactic, target, "opponent");
-      return;
-    }
-
-    // Dual-target cards: opponent picks 2 random justices
-    if (tactic.effectType === "swap-clerks") {
-      const eligibleMultiTargetJustices = getEligibleMultiTargetJustices(tactic);
-      if (eligibleMultiTargetJustices.length < 2) {
-        endOpponentTurn();
-        return;
-      }
-      const shuffled = shuffle([...eligibleMultiTargetJustices]);
-      game.multiTargetMode = true;
-      game.multiTargetTacticId = tactic.id;
-      game.multiTargetSelections = [shuffled[0].id, shuffled[1].id];
-      applyTactic(tactic, null, "opponent");
-      return;
-    }
-
-    // Cards with complex targeting that opponent skips (falls back to another card)
-    if (tactic.effectType === "betray-friend" || tactic.effectType === "invite-church") {
-      const fallback = available.filter((t) => !["betray-friend", "invite-church", "claim-two", "make-chief"].includes(t.effectType));
-      if (!fallback.length) {
-        endOpponentTurn();
-        return;
-      }
-      applyTactic(fallback[Math.floor(Math.random() * fallback.length)], null, "opponent");
-      return;
-    }
-
-    if (tactic.effectType === "recuse") {
-      // Opponent uses recuse to neutralize the player's strongest ally
-      const friendlies = game.bench
-        .filter((j) => !game.playerShields.includes(j.id) && (game.leanings[j.id] ?? 0) > gameSettings.abstentionThreshold)
-        .sort((a, b) => (game.leanings[b.id] ?? 0) - (game.leanings[a.id] ?? 0));
-      if (!friendlies.length) {
-        endOpponentTurn();
-        return;
-      }
-      applyTactic(tactic, friendlies[0], "opponent");
-      return;
-    }
-
-    if (tactic.effectType === "shield") {
-      // Opponent protects its allies (justices leaning against player)
-      const allies = game.bench.filter((j) => (game.leanings[j.id] ?? 0) < 0);
-      if (!allies.length) {
-        // No allies — fall back to a sway card instead
-        const fallback = available.filter((t) => t.effectType !== "shield" && t.effectType !== "claim-two" && t.effectType !== "make-chief");
-        if (!fallback.length) {
-          endOpponentTurn();
-          return;
-        }
-        const fb = fallback[Math.floor(Math.random() * fallback.length)];
-        applyTactic(fb, null, "opponent");
-        return;
-      }
-      applyTactic(tactic, allies[Math.floor(Math.random() * allies.length)], "opponent");
-      return;
-    }
-
-    if (tactic.effectType === "make-chief") {
-      // Opponent tries to elevate a justice they like as chief
-      const candidates = game.bench.filter((j) => j.id !== game.chiefJusticeId && (game.leanings[j.id] ?? 0) < 0);
-      if (!candidates.length) {
-        endOpponentTurn();
-        return;
-      }
-      applyTactic(tactic, candidates[Math.floor(Math.random() * candidates.length)], "opponent");
-      return;
-    }
-
-    // sway-one: target any justice not currently shielded by the player
-    const candidates = game.bench.filter((j) => !game.playerShields.includes(j.id));
-    if (!candidates.length) {
-      endOpponentTurn();
-      return;
-    }
-    applyTactic(tactic, candidates[Math.floor(Math.random() * candidates.length)], "opponent");
-  }
-
-  function endOpponentTurn(): void {
-    // Wake up any justices whose nap ends this round
-    for (const [idStr, napRound] of Object.entries(game.nappingJustices)) {
-      if (napRound <= game.round) {
-        const id = Number(idStr);
-        delete game.nappingJustices[id];
-      }
-    }
-    // Wake up yoga justices and apply their well-being buffs
-    for (const [idStr, yogaRound] of Object.entries(game.yogaJustices)) {
-      if (yogaRound <= game.round) {
-        const id = Number(idStr);
-        delete game.yogaJustices[id];
-        game.statMods[id] = {
-          ...(game.statMods[id] ?? {}),
-          empathy: (game.statMods[id]?.empathy ?? 0) + 3,
-          susceptibility: (game.statMods[id]?.susceptibility ?? 0) + 3,
-        };
-      }
-    }
-    // Shields are consumed on contact (in resolveEffect), not cleared here
-    ui.opponentThinking = false;
-    game.currentTurn = "player";
-
-    triggerLemonMomentIfDue();
-
-    // Mess With The Calendar: if opponent played it, skip player's turn and the entire next round
-    if (game.skipNextRound) {
-      delete game.skipNextRound;
-      game.round += 2; // Skip player's current turn + entire next round
-      game.currentTurn = "opponent";
-
-      if (game.round > gameSettings.numberOfRounds) {
-        void trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
-        setTimeout(() => {
-          ui.phase = "verdict";
-        }, 1500);
-        return;
-      }
-
-      // Continue to opponent's turn in the new round
-      ui.opponentThinking = true;
-      setTimeout(() => playOpponentTurn(), 1000);
-      return;
-    }
-
-    if (game.round >= gameSettings.numberOfRounds) {
-      void trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
-      setTimeout(() => {
-        ui.phase = "verdict";
-      }, 1500);
-    } else {
-      game.round++;
-    }
-  }
-
-  // ─── Computed ────────────────────────────────────────────────
-
-  const sortedBench = computed(() =>
-    [...game.bench].sort((a, b) => {
-      if (a.id === game.chiefJusticeId) return -1;
-      if (b.id === game.chiefJusticeId) return 1;
-      return 0;
-    }),
-  );
-
-  // True when at least one bench justice is Strongly For (leaning >= 60) — gates Betray Your Friend
-  const hasStrongAlly = computed(() => game.bench.some((j) => (game.leanings[j.id] ?? 0) >= 60));
-
-  /** For the Reframe The Debate picker: counts of FOR/AGAINST per stance choice on the current bench. */
-  const reframeStanceStats = computed(() => {
-    return game.reframeStanceChoices.map((stance) => {
-      let forCount = 0;
-      let againstCount = 0;
-      game.bench.forEach((j) => {
-        const s = j.stances?.find((st) => st.topic === stance);
-        if (!s || s.position === "Neutral") return;
-        if (s.position === "For") forCount++;
-        else againstCount++;
-      });
-      return { stance, forCount, againstCount };
-    });
-  });
-
-  const benchOverview = computed(() => {
-    const bench = game.bench;
-    if (!bench.length) return null;
-    const maleCount = bench.filter((j) => j.gender === "M").length;
-    const femaleCount = bench.filter((j) => j.gender === "F").length;
-    const partyCounts: Record<string, number> = {};
-    bench.forEach((j) => {
-      const raw = j.nominatedBy?.party ?? "Unknown";
-      // Justices are displayed as Conservative/Liberal rather than Republican/Democrat
-      const label =
-        raw === "Republican" || raw === "Federalist" || raw === "Whig"
-          ? "Conservative"
-          : raw === "Democrat" || raw === "Democratic-Republican"
-            ? "Liberal"
-            : raw;
-      partyCounts[label] = (partyCounts[label] ?? 0) + 1;
-    });
-    const statKeys = ["logic", "charisma", "empathy", "susceptibility", "partyLoyalty"] as const;
-    const statAvg = (k: (typeof statKeys)[number]) => bench.reduce((s, j) => s + j.stats[k], 0) / bench.length;
-    const bestStat = statKeys.reduce((a, b) => (statAvg(a) >= statAvg(b) ? a : b));
-    const worstStat = statKeys.reduce((a, b) => (statAvg(a) <= statAvg(b) ? a : b));
-    const weaknessKeys = ["flattery", "bribery", "blackmail", "threats"] as const;
-    const wkAvg = (k: (typeof weaknessKeys)[number]) => bench.reduce((s, j) => s + j.weaknesses[k], 0) / bench.length;
-    const greatestWeakness = weaknessKeys.reduce((a, b) => (wkAvg(a) >= wkAvg(b) ? a : b));
-    const t = gameSettings.abstentionThreshold;
-    const votingFor = bench.filter((j) => (game.leanings[j.id] ?? 0) >= t).length;
-    const votingAgainst = bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t).length;
-    const abstaining = bench.length - votingFor - votingAgainst;
-    return { maleCount, femaleCount, partyCounts, bestStat, worstStat, greatestWeakness, votingFor, votingAgainst, abstaining };
-  });
-
-  const verdict = computed(() => {
-    if (!game.bench.length) return null;
-    const t = gameSettings.abstentionThreshold;
-    const forCount = game.bench.filter((j) => (game.leanings[j.id] ?? 0) >= t).length;
-    const againstCount = game.bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t).length;
-    const abstainCount = game.bench.length - forCount - againstCount;
-    return { forCount, againstCount, abstainCount, won: forCount > againstCount, tied: forCount === againstCount };
-  });
-
-  // ── Campaign composable (must come after `verdict` is defined) ──
   const {
     startCampaign: beginCampaign,
     chooseObjective: pickObjective,
@@ -1294,261 +975,6 @@
   function proceedFromRecess(): void {
     moveFromRecess();
     maybeTrackCampaignCompletion();
-  }
-
-  const tallyDisplay = computed(() => {
-    if (!benchOverview.value) return "0-0";
-    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
-    return abstaining > 0 ? `${votingFor}-${votingAgainst}-${abstaining}` : `${votingFor}-${votingAgainst}`;
-  });
-
-  const tallyClass = computed(() => {
-    if (!benchOverview.value) return "";
-    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
-    return [votingFor > votingAgainst ? "is-winning" : "is-losing", abstaining > 0 ? "has-abstentions" : ""].filter(Boolean).join(" ");
-  });
-
-  const tallyTooltip = computed(() => {
-    if (!benchOverview.value) return "";
-    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
-    const parts = [`${votingFor} for you`, `${votingAgainst} against you`];
-    if (abstaining > 0) parts.push(`${abstaining} abstaining`);
-    return parts.join(" · ");
-  });
-
-  const reportByRound = computed(() =>
-    Array.from({ length: gameSettings.numberOfRounds }, (_, i) => {
-      const r = i + 1;
-      const roundPlays = courtReport.plays.filter((p) => p.round === r);
-      const playerPlay = roundPlays.find((p) => p.actor === "player") ?? null;
-      const opponentPlay = roundPlays.find((p) => p.actor === "opponent") ?? null;
-      const allResults = roundPlays.flatMap((p) => p.results);
-      const netTraction = allResults.reduce((sum, res) => sum + res.change, 0);
-
-      // Party-level breakdown — cross-reference with current bench by name
-      const byParty: Record<string, number> = {};
-      allResults.forEach((res) => {
-        const justice = game.bench.find((j) => j.name === res.justiceName);
-        const party = justice?.nominatedBy?.party ?? "Unknown";
-        byParty[party] = (byParty[party] ?? 0) + res.change;
-      });
-      const tractionByParty = Object.fromEntries(Object.entries(byParty).filter(([, v]) => v !== 0));
-
-      return {
-        round: r,
-        playerPlay,
-        opponentPlay,
-        netTraction,
-        tractionByParty,
-        leansToward: netTraction > 0 ? "player" : netTraction < 0 ? "opponent" : "neutral",
-        hasPlays: roundPlays.length > 0,
-        isFuture: r > game.round,
-      };
-    }),
-  );
-
-  // ─── UI Helpers ──────────────────────────────────────────────
-
-  function getKeyStats(justice: Justice): Record<string, number> {
-    return {
-      Logic: justice.stats.logic,
-      Charisma: justice.stats.charisma,
-      Loyalty: justice.stats.partyLoyalty,
-    };
-  }
-
-  function justiceTypeLabel(type: Justice["justiceType"]): string {
-    return { current: "Current", historical: "Historical", fictional: "Fictional", celebrity: "Celebrity" }[type] ?? type;
-  }
-
-  /** Returns sorted stance chips for a case side display. */
-  function sideStanceTags(stances?: Partial<Record<string, StanceOpinion>>): { label: string; position: StanceOpinion }[] {
-    if (!stances) return [];
-    return (Object.entries(stances) as [string, StanceOpinion][])
-      .filter(([, pos]) => pos !== "Neutral")
-      .map(([topic, position]) => ({ label: topic.replace(/([A-Z])/g, " $1").trim(), position }))
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }
-
-  function targetLabel(effectType: Tactic["effectType"]): string {
-    return (
-      {
-        "sway-one": "🎯 Single target",
-        "sway-all": "🌊 All justices",
-        "request-amicus": "📚 All justices",
-        "recite-dissent": "📖 No target",
-        "catch-phone": "📱 Single target",
-        "plant-story": "🌱 Single target",
-        susceptibility: "😴 All justices",
-        "lemon-test": "🍋 All justices",
-        shield: "🛡️ Ally only",
-        "discard-all": "🗑️ Playbook",
-        "claim-two": "🗑️ Playbook",
-        "make-chief": "👑 Chief Justice",
-        "insult-chief": "👑 Chief Justice",
-        "presidential-call": "📞 All justices",
-        recuse: "🔕 Single target",
-        "betray-friend": "🗡️ Strongly For only",
-        "swap-clerks": "🔄 Two justices",
-        "encourage-nap": "💤 Single target",
-        "justice-cocktails": "🍸 Single target",
-        "saint-patricks": "☘️ All justices",
-        "invite-church": "⛪ Single target",
-        "suggest-retirement": "🏖️ Single target",
-        "keep-crown": "👑 Chief Justice",
-        "gift-boxes": "🎁 All justices",
-        "drag-them": "🎯 Single target",
-        "whisper-campaign": "🎯 Single target",
-        "fog-machine": "🪩 All justices",
-        "alien-abduction": "👽 All justices",
-        "mess-calendar": "📅 Skip a day",
-        "international-law": "🌍 All justices",
-      }[effectType] ?? effectType
-    );
-  }
-
-  function voteMeterStyle(justice: Justice): Record<string, string> {
-    const leaning = game.leanings[justice.id] ?? 0;
-    const halfPct = (Math.abs(leaning) / 100) * 50;
-    const color = leaning > 0 ? "#2a7a3a" : leaning < 0 ? "#8b2020" : "transparent";
-    if (leaning >= 0) {
-      return { left: "50%", width: `${halfPct}%`, backgroundColor: color };
-    } else {
-      return { left: `${50 - halfPct}%`, width: `${halfPct}%`, backgroundColor: color };
-    }
-  }
-
-  // ─── Verdict computeds ───────────────────────────────────────
-
-  const verdictSections = computed(() => {
-    if (!verdict.value || !game.bench.length) return [];
-    const t = gameSettings.abstentionThreshold;
-    const forJustices = game.bench.filter((j) => (game.leanings[j.id] ?? 0) >= t);
-    const againstJustices = game.bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t);
-    const abstainJustices = game.bench.filter((j) => {
-      const l = game.leanings[j.id] ?? 0;
-      return l > -t && l < t;
-    });
-    const sections = [
-      { label: "Votes For", justices: forJustices, type: "for" as const },
-      { label: "Votes Against", justices: againstJustices, type: "against" as const },
-      { label: "Abstaining", justices: abstainJustices, type: "abstain" as const },
-    ].filter((s) => s.justices.length > 0);
-    // If player lost (not tied), put the "against" section first
-    if (!verdict.value.won && !verdict.value.tied) {
-      const againstIdx = sections.findIndex((s) => s.type === "against");
-      if (againstIdx > 0) {
-        const [against] = sections.splice(againstIdx, 1);
-        sections.unshift(against);
-      }
-    }
-    return sections;
-  });
-
-  const verdictRuledFor = computed(() => {
-    if (!verdict.value || !game.currentCase || !game.playerSide || verdict.value.tied) return "";
-    if (verdict.value.won) {
-      return game.playerSide === "prosecution" ? game.currentCase.prosecution.name : game.currentCase.defendant.name;
-    }
-    return game.playerSide === "prosecution" ? game.currentCase.defendant.name : game.currentCase.prosecution.name;
-  });
-
-  const verdictWinningArgument = computed(() => {
-    if (!verdict.value || !game.currentCase || !game.playerSide || verdict.value.tied) return "";
-    const winningSide = verdict.value.won ? game.playerSide : game.playerSide === "prosecution" ? "defendant" : "prosecution";
-    return winningSide === "prosecution" ? game.currentCase.prosecution.argument : game.currentCase.defendant.argument;
-  });
-
-  const verdictScoreDisplay = computed(() => {
-    if (!verdict.value) return "";
-    const { forCount, againstCount, abstainCount } = verdict.value;
-    return abstainCount > 0 ? `${forCount}\u2013${againstCount}\u2013${abstainCount}` : `${forCount}\u2013${againstCount}`;
-  });
-
-  // Maps justice id → list of plays that directly targeted them (by name match)
-  const justiceTargetings = computed(() => {
-    const map: Record<number, Array<{ tacticName: string; actor: TurnActor }>> = {};
-    courtReport.plays.forEach((play) => {
-      const justice = game.bench.find((j) => j.name === play.targetName);
-      if (justice) {
-        if (!map[justice.id]) map[justice.id] = [];
-        map[justice.id].push({ tacticName: play.tacticName, actor: play.actor });
-      }
-    });
-    return map;
-  });
-
-  function verdictJusticeBarStyle(justice: Justice): Record<string, string> {
-    const leaning = game.leanings[justice.id] ?? 0;
-    const pct = Math.abs(leaning);
-    const color = leaning >= gameSettings.abstentionThreshold ? "#2a7a3a" : leaning <= -gameSettings.abstentionThreshold ? "#8b2020" : "#5a4a3a";
-    return { width: `${pct}%`, backgroundColor: color };
-  }
-
-  const chiefJustice = computed(() => game.bench.find((j) => j.id === game.chiefJusticeId) ?? null);
-
-  const benchLabel = computed(() => {
-    if (!chiefJustice.value) return "The Bench";
-    // For preset modes (except 'current'), use the preset's display name
-    if (ui.courtMode && ui.courtMode !== "current") {
-      const preset = presetBenchConfigs.find((b) => b.id === ui.courtMode);
-      if (preset) return preset.name;
-    }
-    const courtName = chiefJustice.value.courtName;
-    const label = courtName ?? chiefJustice.value.name.split(" ").at(-1);
-    return `The ${label} Court`;
-  });
-
-  const previewPreset = computed(() => {
-    if (!ui.previewPresetId) return null;
-    return presetBenchConfigs.find((b) => b.id === ui.previewPresetId) ?? null;
-  });
-
-  const previewPresetChief = computed(() => {
-    if (!previewPreset.value) return null;
-    return allJustices.value.find((j) => j.id === previewPreset.value!.chiefJusticeId) ?? null;
-  });
-
-  function voteLabel(leaning: number): string {
-    const t = gameSettings.abstentionThreshold;
-    if (leaning >= 60) return "Strongly For";
-    if (leaning >= t) return "Leaning For";
-    if (leaning > -t) return "Undecided";
-    if (leaning > -60) return "Leaning Against";
-    return "Strongly Against";
-  }
-
-  function justiceImageUrl(justice: Justice): string | null {
-    return justice.image ? `/img/court/justices/${justice.image}` : null;
-  }
-
-  function presidentImageUrl(president: President): string | null {
-    return president.image ? `/img/court/presidents/${president.image}` : null;
-  }
-
-  function justiceHints(justice: Justice, limit = 4): string[] {
-    const hints: string[] = [];
-    if (justice.stats.partyLoyalty >= 8) hints.push("📌 Deeply partisan");
-    else if (justice.stats.partyLoyalty <= 3) hints.push("🎯 Votes independently");
-    if (justice.weaknesses.flattery >= 7) hints.push("😊 Loves being flattered");
-    else if (justice.weaknesses.flattery <= 2) hints.push("🙄 Immune to flattery");
-    if (justice.weaknesses.bribery >= 7) hints.push("💰 Open to bribery");
-    else if (justice.weaknesses.bribery <= 2) hints.push("🚫 Incorruptible");
-    if (justice.weaknesses.blackmail >= 7) hints.push("🤫 Has something to hide");
-    else if (justice.weaknesses.blackmail <= 2) hints.push("🩻 Difficult to blackmail");
-    if (justice.weaknesses.threats >= 7) hints.push("😰 Unnerved by pressure");
-    else if (justice.weaknesses.threats <= 2) hints.push("🦁 Nearly impossible to threaten");
-    if (justice.stats.susceptibility >= 7) hints.push("🌀 Easily swayed");
-    else if (justice.stats.susceptibility <= 3) hints.push("🪨 Hard to budge");
-    if (justice.stats.empathy >= 8) hints.push("❤️ Responds to emotional appeals");
-    else if (justice.stats.empathy <= 2) hints.push("🧊 Cold to emotional arguments");
-    if (justice.stats.logic >= 8) hints.push("📚 Won over by sound reasoning");
-    else if (justice.stats.logic <= 3) hints.push("❓ Logic rarely lands here");
-    return hints.slice(0, limit);
-  }
-
-  function justiceVoteHistory(justice: Justice): Array<{ caseName: string; votedFor: boolean }> {
-    return caseHistory.filter((c) => justice.id in c.votes).map((c) => ({ caseName: c.caseName, votedFor: c.votes[justice.id] }));
   }
 
   onMounted(() => {

--- a/src/views/court/ts/_useCourtComputeds.ts
+++ b/src/views/court/ts/_useCourtComputeds.ts
@@ -1,0 +1,257 @@
+import { computed } from "vue";
+import type { CourtGameState, TurnActor } from "./_types";
+import {
+  currentJustices,
+  historicalJustices,
+  fictionalJustices,
+  celebrityJustices,
+  warrenJustices,
+  lochnerJustices,
+  presetBenchConfigs,
+} from "./justices";
+import { gameSettings } from "./_settings";
+
+interface CourtPlay {
+  actor: TurnActor;
+  tacticName: string;
+  cardType: string;
+  targetName: string;
+  results: { justiceName: string; change: number }[];
+  round: number;
+}
+
+interface CourtComputedsDeps {
+  game: CourtGameState;
+  ui: { courtMode: string | null; previewPresetId: string | null };
+  courtReport: { plays: CourtPlay[] };
+}
+
+export function useCourtComputeds({ game, ui, courtReport }: CourtComputedsDeps) {
+  const allJustices = computed(() => [
+    ...currentJustices,
+    ...historicalJustices,
+    ...fictionalJustices,
+    ...celebrityJustices,
+    ...warrenJustices,
+    ...lochnerJustices,
+  ]);
+
+  const historicalPresets = computed(() => presetBenchConfigs.filter((b) => ["current", "warren-court", "lochner-era"].includes(b.id)));
+  const fictionalPresets = computed(() => presetBenchConfigs.filter((b) => !["current", "warren-court", "lochner-era"].includes(b.id)));
+
+  const sortedBench = computed(() =>
+    [...game.bench].sort((a, b) => {
+      if (a.id === game.chiefJusticeId) return -1;
+      if (b.id === game.chiefJusticeId) return 1;
+      return 0;
+    }),
+  );
+
+  const hasStrongAlly = computed(() => game.bench.some((j) => (game.leanings[j.id] ?? 0) >= 60));
+
+  const reframeStanceStats = computed(() => {
+    return game.reframeStanceChoices.map((stance) => {
+      let forCount = 0;
+      let againstCount = 0;
+      game.bench.forEach((j) => {
+        const s = j.stances?.find((st) => st.topic === stance);
+        if (!s || s.position === "Neutral") return;
+        if (s.position === "For") forCount++;
+        else againstCount++;
+      });
+      return { stance, forCount, againstCount };
+    });
+  });
+
+  const benchOverview = computed(() => {
+    const bench = game.bench;
+    if (!bench.length) return null;
+    const maleCount = bench.filter((j) => j.gender === "M").length;
+    const femaleCount = bench.filter((j) => j.gender === "F").length;
+    const partyCounts: Record<string, number> = {};
+    bench.forEach((j) => {
+      const raw = j.nominatedBy?.party ?? "Unknown";
+      const label =
+        raw === "Republican" || raw === "Federalist" || raw === "Whig"
+          ? "Conservative"
+          : raw === "Democrat" || raw === "Democratic-Republican"
+            ? "Liberal"
+            : raw;
+      partyCounts[label] = (partyCounts[label] ?? 0) + 1;
+    });
+    const statKeys = ["logic", "charisma", "empathy", "susceptibility", "partyLoyalty"] as const;
+    const statAvg = (k: (typeof statKeys)[number]) => bench.reduce((s, j) => s + j.stats[k], 0) / bench.length;
+    const bestStat = statKeys.reduce((a, b) => (statAvg(a) >= statAvg(b) ? a : b));
+    const worstStat = statKeys.reduce((a, b) => (statAvg(a) <= statAvg(b) ? a : b));
+    const weaknessKeys = ["flattery", "bribery", "blackmail", "threats"] as const;
+    const wkAvg = (k: (typeof weaknessKeys)[number]) => bench.reduce((s, j) => s + j.weaknesses[k], 0) / bench.length;
+    const greatestWeakness = weaknessKeys.reduce((a, b) => (wkAvg(a) >= wkAvg(b) ? a : b));
+    const t = gameSettings.abstentionThreshold;
+    const votingFor = bench.filter((j) => (game.leanings[j.id] ?? 0) >= t).length;
+    const votingAgainst = bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t).length;
+    const abstaining = bench.length - votingFor - votingAgainst;
+    return { maleCount, femaleCount, partyCounts, bestStat, worstStat, greatestWeakness, votingFor, votingAgainst, abstaining };
+  });
+
+  const verdict = computed(() => {
+    if (!game.bench.length) return null;
+    const t = gameSettings.abstentionThreshold;
+    const forCount = game.bench.filter((j) => (game.leanings[j.id] ?? 0) >= t).length;
+    const againstCount = game.bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t).length;
+    const abstainCount = game.bench.length - forCount - againstCount;
+    return { forCount, againstCount, abstainCount, won: forCount > againstCount, tied: forCount === againstCount };
+  });
+
+  const tallyDisplay = computed(() => {
+    if (!benchOverview.value) return "0-0";
+    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
+    return abstaining > 0 ? `${votingFor}-${votingAgainst}-${abstaining}` : `${votingFor}-${votingAgainst}`;
+  });
+
+  const tallyClass = computed(() => {
+    if (!benchOverview.value) return "";
+    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
+    return [votingFor > votingAgainst ? "is-winning" : "is-losing", abstaining > 0 ? "has-abstentions" : ""].filter(Boolean).join(" ");
+  });
+
+  const tallyTooltip = computed(() => {
+    if (!benchOverview.value) return "";
+    const { votingFor, votingAgainst, abstaining } = benchOverview.value;
+    const parts = [`${votingFor} for you`, `${votingAgainst} against you`];
+    if (abstaining > 0) parts.push(`${abstaining} abstaining`);
+    return parts.join(" · ");
+  });
+
+  const reportByRound = computed(() =>
+    Array.from({ length: gameSettings.numberOfRounds }, (_, i) => {
+      const r = i + 1;
+      const roundPlays = courtReport.plays.filter((p) => p.round === r);
+      const playerPlay = roundPlays.find((p) => p.actor === "player") ?? null;
+      const opponentPlay = roundPlays.find((p) => p.actor === "opponent") ?? null;
+      const allResults = roundPlays.flatMap((p) => p.results);
+      const netTraction = allResults.reduce((sum, res) => sum + res.change, 0);
+
+      const byParty: Record<string, number> = {};
+      allResults.forEach((res) => {
+        const justice = game.bench.find((j) => j.name === res.justiceName);
+        const party = justice?.nominatedBy?.party ?? "Unknown";
+        byParty[party] = (byParty[party] ?? 0) + res.change;
+      });
+      const tractionByParty = Object.fromEntries(Object.entries(byParty).filter(([, v]) => v !== 0));
+
+      return {
+        round: r,
+        playerPlay,
+        opponentPlay,
+        netTraction,
+        tractionByParty,
+        leansToward: netTraction > 0 ? "player" : netTraction < 0 ? "opponent" : "neutral",
+        hasPlays: roundPlays.length > 0,
+        isFuture: r > game.round,
+      };
+    }),
+  );
+
+  const verdictSections = computed(() => {
+    if (!verdict.value || !game.bench.length) return [];
+    const t = gameSettings.abstentionThreshold;
+    const forJustices = game.bench.filter((j) => (game.leanings[j.id] ?? 0) >= t);
+    const againstJustices = game.bench.filter((j) => (game.leanings[j.id] ?? 0) <= -t);
+    const abstainJustices = game.bench.filter((j) => {
+      const l = game.leanings[j.id] ?? 0;
+      return l > -t && l < t;
+    });
+    const sections = [
+      { label: "Votes For", justices: forJustices, type: "for" as const },
+      { label: "Votes Against", justices: againstJustices, type: "against" as const },
+      { label: "Abstaining", justices: abstainJustices, type: "abstain" as const },
+    ].filter((s) => s.justices.length > 0);
+    if (!verdict.value.won && !verdict.value.tied) {
+      const againstIdx = sections.findIndex((s) => s.type === "against");
+      if (againstIdx > 0) {
+        const [against] = sections.splice(againstIdx, 1);
+        sections.unshift(against);
+      }
+    }
+    return sections;
+  });
+
+  const verdictRuledFor = computed(() => {
+    if (!verdict.value || !game.currentCase || !game.playerSide || verdict.value.tied) return "";
+    if (verdict.value.won) {
+      return game.playerSide === "prosecution" ? game.currentCase.prosecution.name : game.currentCase.defendant.name;
+    }
+    return game.playerSide === "prosecution" ? game.currentCase.defendant.name : game.currentCase.prosecution.name;
+  });
+
+  const verdictWinningArgument = computed(() => {
+    if (!verdict.value || !game.currentCase || !game.playerSide || verdict.value.tied) return "";
+    const winningSide = verdict.value.won ? game.playerSide : game.playerSide === "prosecution" ? "defendant" : "prosecution";
+    return winningSide === "prosecution" ? game.currentCase.prosecution.argument : game.currentCase.defendant.argument;
+  });
+
+  const verdictScoreDisplay = computed(() => {
+    if (!verdict.value) return "";
+    const { forCount, againstCount, abstainCount } = verdict.value;
+    return abstainCount > 0 ? `${forCount}–${againstCount}–${abstainCount}` : `${forCount}–${againstCount}`;
+  });
+
+  const justiceTargetings = computed(() => {
+    const map: Record<number, Array<{ tacticName: string; actor: TurnActor }>> = {};
+    courtReport.plays.forEach((play) => {
+      const justice = game.bench.find((j) => j.name === play.targetName);
+      if (justice) {
+        if (!map[justice.id]) map[justice.id] = [];
+        map[justice.id].push({ tacticName: play.tacticName, actor: play.actor });
+      }
+    });
+    return map;
+  });
+
+  const chiefJustice = computed(() => game.bench.find((j) => j.id === game.chiefJusticeId) ?? null);
+
+  const benchLabel = computed(() => {
+    if (!chiefJustice.value) return "The Bench";
+    if (ui.courtMode && ui.courtMode !== "current") {
+      const preset = presetBenchConfigs.find((b) => b.id === ui.courtMode);
+      if (preset) return preset.name;
+    }
+    const courtName = chiefJustice.value.courtName;
+    const label = courtName ?? chiefJustice.value.name.split(" ").at(-1);
+    return `The ${label} Court`;
+  });
+
+  const previewPreset = computed(() => {
+    if (!ui.previewPresetId) return null;
+    return presetBenchConfigs.find((b) => b.id === ui.previewPresetId) ?? null;
+  });
+
+  const previewPresetChief = computed(() => {
+    if (!previewPreset.value) return null;
+    return allJustices.value.find((j) => j.id === previewPreset.value!.chiefJusticeId) ?? null;
+  });
+
+  return {
+    allJustices,
+    historicalPresets,
+    fictionalPresets,
+    sortedBench,
+    hasStrongAlly,
+    reframeStanceStats,
+    benchOverview,
+    verdict,
+    tallyDisplay,
+    tallyClass,
+    tallyTooltip,
+    reportByRound,
+    verdictSections,
+    verdictRuledFor,
+    verdictWinningArgument,
+    verdictScoreDisplay,
+    justiceTargetings,
+    chiefJustice,
+    benchLabel,
+    previewPreset,
+    previewPresetChief,
+  };
+}

--- a/src/views/court/ts/_useCourtHelpers.ts
+++ b/src/views/court/ts/_useCourtHelpers.ts
@@ -1,0 +1,139 @@
+import type { Justice, CourtGameState, President, Tactic } from "./_types";
+import { gameSettings } from "./_settings";
+
+interface CaseHistoryEntry {
+  caseName: string;
+  votes: Record<number, boolean>;
+}
+
+export function useCourtHelpers(game: CourtGameState, caseHistory: CaseHistoryEntry[]) {
+  function voteMeterStyle(justice: Justice): Record<string, string> {
+    const leaning = game.leanings[justice.id] ?? 0;
+    const halfPct = (Math.abs(leaning) / 100) * 50;
+    const color = leaning > 0 ? "#2a7a3a" : leaning < 0 ? "#8b2020" : "transparent";
+    if (leaning >= 0) {
+      return { left: "50%", width: `${halfPct}%`, backgroundColor: color };
+    } else {
+      return { left: `${50 - halfPct}%`, width: `${halfPct}%`, backgroundColor: color };
+    }
+  }
+
+  function verdictJusticeBarStyle(justice: Justice): Record<string, string> {
+    const leaning = game.leanings[justice.id] ?? 0;
+    const pct = Math.abs(leaning);
+    const color =
+      leaning >= gameSettings.abstentionThreshold
+        ? "#2a7a3a"
+        : leaning <= -gameSettings.abstentionThreshold
+          ? "#8b2020"
+          : "#5a4a3a";
+    return { width: `${pct}%`, backgroundColor: color };
+  }
+
+  function justiceVoteHistory(justice: Justice): Array<{ caseName: string; votedFor: boolean }> {
+    return caseHistory.filter((c) => justice.id in c.votes).map((c) => ({ caseName: c.caseName, votedFor: c.votes[justice.id] }));
+  }
+
+  return { voteMeterStyle, verdictJusticeBarStyle, justiceVoteHistory };
+}
+
+// ── Pure helper functions ─────────────────────────────────────────────────────
+
+export function getKeyStats(justice: Justice): Record<string, number> {
+  return {
+    Logic: justice.stats.logic,
+    Charisma: justice.stats.charisma,
+    Loyalty: justice.stats.partyLoyalty,
+  };
+}
+
+export function justiceTypeLabel(type: Justice["justiceType"]): string {
+  return { current: "Current", historical: "Historical", fictional: "Fictional", celebrity: "Celebrity" }[type] ?? type;
+}
+
+export function sideStanceTags(
+  stances?: Partial<Record<string, string>>,
+): { label: string; position: string }[] {
+  if (!stances) return [];
+  return (Object.entries(stances) as [string, string][])
+    .filter(([, pos]) => pos !== "Neutral")
+    .map(([topic, position]) => ({ label: topic.replace(/([A-Z])/g, " $1").trim(), position }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function targetLabel(effectType: Tactic["effectType"]): string {
+  return (
+    {
+      "sway-one": "🎯 Single target",
+      "sway-all": "🌊 All justices",
+      "request-amicus": "📚 All justices",
+      "recite-dissent": "📖 No target",
+      "catch-phone": "📱 Single target",
+      "plant-story": "🌱 Single target",
+      susceptibility: "😴 All justices",
+      "lemon-test": "🍋 All justices",
+      shield: "🛡️ Ally only",
+      "discard-all": "🗑️ Playbook",
+      "claim-two": "🗑️ Playbook",
+      "make-chief": "👑 Chief Justice",
+      "insult-chief": "👑 Chief Justice",
+      "presidential-call": "📞 All justices",
+      recuse: "🔕 Single target",
+      "betray-friend": "🗡️ Strongly For only",
+      "swap-clerks": "🔄 Two justices",
+      "encourage-nap": "💤 Single target",
+      "justice-cocktails": "🍸 Single target",
+      "saint-patricks": "☘️ All justices",
+      "invite-church": "⛪ Single target",
+      "suggest-retirement": "🏖️ Single target",
+      "keep-crown": "👑 Chief Justice",
+      "gift-boxes": "🎁 All justices",
+      "drag-them": "🎯 Single target",
+      "whisper-campaign": "🎯 Single target",
+      "fog-machine": "🪩 All justices",
+      "alien-abduction": "👽 All justices",
+      "mess-calendar": "📅 Skip a day",
+      "international-law": "🌍 All justices",
+      "reframe-debate": "📣 Choose a stance",
+      "suggest-yoga": "🧘 Single target",
+    }[effectType] ?? effectType
+  );
+}
+
+export function voteLabel(leaning: number): string {
+  const t = gameSettings.abstentionThreshold;
+  if (leaning >= 60) return "Strongly For";
+  if (leaning >= t) return "Leaning For";
+  if (leaning > -t) return "Undecided";
+  if (leaning > -60) return "Leaning Against";
+  return "Strongly Against";
+}
+
+export function justiceImageUrl(justice: Justice): string | null {
+  return justice.image ? `/img/court/justices/${justice.image}` : null;
+}
+
+export function presidentImageUrl(president: President): string | null {
+  return president.image ? `/img/court/presidents/${president.image}` : null;
+}
+
+export function justiceHints(justice: Justice, limit = 4): string[] {
+  const hints: string[] = [];
+  if (justice.stats.partyLoyalty >= 8) hints.push("📌 Deeply partisan");
+  else if (justice.stats.partyLoyalty <= 3) hints.push("🎯 Votes independently");
+  if (justice.weaknesses.flattery >= 7) hints.push("😊 Loves being flattered");
+  else if (justice.weaknesses.flattery <= 2) hints.push("🙄 Immune to flattery");
+  if (justice.weaknesses.bribery >= 7) hints.push("💰 Open to bribery");
+  else if (justice.weaknesses.bribery <= 2) hints.push("🚫 Incorruptible");
+  if (justice.weaknesses.blackmail >= 7) hints.push("🤫 Has something to hide");
+  else if (justice.weaknesses.blackmail <= 2) hints.push("🩻 Difficult to blackmail");
+  if (justice.weaknesses.threats >= 7) hints.push("😰 Unnerved by pressure");
+  else if (justice.weaknesses.threats <= 2) hints.push("🦁 Nearly impossible to threaten");
+  if (justice.stats.susceptibility >= 7) hints.push("🌀 Easily swayed");
+  else if (justice.stats.susceptibility <= 3) hints.push("🪨 Hard to budge");
+  if (justice.stats.empathy >= 8) hints.push("❤️ Responds to emotional appeals");
+  else if (justice.stats.empathy <= 2) hints.push("🧊 Cold to emotional arguments");
+  if (justice.stats.logic >= 8) hints.push("📚 Won over by sound reasoning");
+  else if (justice.stats.logic <= 3) hints.push("❓ Logic rarely lands here");
+  return hints.slice(0, limit);
+}

--- a/src/views/court/ts/_useCourtHelpers.ts
+++ b/src/views/court/ts/_useCourtHelpers.ts
@@ -1,4 +1,4 @@
-import type { Justice, CourtGameState, President, Tactic } from "./_types";
+import type { Justice, CourtGameState, President, Tactic, StanceOpinion } from "./_types";
 import { gameSettings } from "./_settings";
 
 interface CaseHistoryEntry {
@@ -52,10 +52,10 @@ export function justiceTypeLabel(type: Justice["justiceType"]): string {
 }
 
 export function sideStanceTags(
-  stances?: Partial<Record<string, string>>,
-): { label: string; position: string }[] {
+  stances?: Partial<Record<string, StanceOpinion>>,
+): { label: string; position: StanceOpinion }[] {
   if (!stances) return [];
-  return (Object.entries(stances) as [string, string][])
+  return (Object.entries(stances) as [string, StanceOpinion][])
     .filter(([, pos]) => pos !== "Neutral")
     .map(([topic, position]) => ({ label: topic.replace(/([A-Z])/g, " $1").trim(), position }))
     .sort((a, b) => a.label.localeCompare(b.label));

--- a/src/views/court/ts/_useCourtTurns.ts
+++ b/src/views/court/ts/_useCourtTurns.ts
@@ -1,0 +1,253 @@
+import type { CourtGameState, CampaignState, Justice, Tactic, TurnActor } from "./_types";
+import { gameSettings } from "./_settings";
+
+interface TurnUiAccess {
+  phase: string;
+  isCampaignMode: boolean;
+  opponentThinking: boolean;
+  opponentHighlightedCardId: number | null;
+}
+
+/* eslint-disable no-unused-vars -- base eslint rule incorrectly flags TS interface method parameter names */
+interface TurnDeps {
+  trackTrialVerdictStats: (opts: { isQuickplay: boolean }) => Promise<void>;
+  applyTactic: (tactic: Tactic, target: Justice | null, actor: TurnActor) => void;
+  shuffle: <T>(arr: T[]) => T[];
+  triggerLemonMomentIfDue: () => void;
+}
+/* eslint-enable no-unused-vars */
+
+export function useCourtTurns(
+  game: CourtGameState,
+  campaign: { data: CampaignState | null },
+  ui: TurnUiAccess,
+  deps: TurnDeps,
+) {
+  // ── Eligible Multi-Target Justices ────────────────────────────
+
+  function getEligibleMultiTargetJustices(tactic: Tactic | null): Justice[] {
+    if (!tactic) return [];
+    if (tactic.effectType === "swap-clerks") {
+      return game.bench.filter((justice) => !(justice.id in game.nappingJustices) && !game.recusedJustices.includes(justice.id));
+    }
+    return [];
+  }
+
+  // ── Turn Flow ─────────────────────────────────────────────────
+
+  function endPlayerTurn(): void {
+    if (campaign.data?.doubleTapActive) {
+      campaign.data.doubleTapActive = false;
+      return;
+    }
+
+    if (game.skipNextRound) {
+      delete game.skipNextRound;
+      game.round += 2;
+      game.currentTurn = "player";
+      deps.triggerLemonMomentIfDue();
+
+      if (game.round > gameSettings.numberOfRounds) {
+        void deps.trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
+        setTimeout(() => {
+          ui.phase = "verdict";
+        }, 1500);
+      }
+      return;
+    }
+
+    game.currentTurn = "opponent";
+    ui.opponentThinking = true;
+
+    const thinkTime = 4000 + Math.random() * 2000;
+    const browseInterval = 650;
+    let elapsed = 0;
+
+    const browseTimer = setInterval(() => {
+      elapsed += browseInterval;
+      const available = game.playbook.filter((t) => t.effectType !== "claim-two");
+      if (available.length) {
+        const pick = available[Math.floor(Math.random() * available.length)];
+        ui.opponentHighlightedCardId = pick.id;
+      }
+      if (elapsed >= thinkTime) {
+        clearInterval(browseTimer);
+        ui.opponentHighlightedCardId = null;
+        setTimeout(() => playOpponentTurn(), 200);
+      }
+    }, browseInterval);
+  }
+
+  function playOpponentTurn(): void {
+    const available = game.playbook.filter(
+      (t) => t.effectType !== "claim-two" && t.effectType !== "suggest-retirement" && t.effectType !== "keep-crown",
+    );
+    if (!available.length) {
+      endOpponentTurn();
+      return;
+    }
+    const tactic = available[Math.floor(Math.random() * available.length)];
+
+    if (
+      tactic.effectType === "sway-all" ||
+      tactic.effectType === "request-amicus" ||
+      tactic.effectType === "susceptibility" ||
+      tactic.effectType === "discard-all" ||
+      tactic.effectType === "recite-dissent" ||
+      tactic.effectType === "insult-chief" ||
+      tactic.effectType === "presidential-call" ||
+      tactic.effectType === "saint-patricks" ||
+      tactic.effectType === "lemon-test" ||
+      tactic.effectType === "fog-machine" ||
+      tactic.effectType === "alien-abduction" ||
+      tactic.effectType === "mess-calendar" ||
+      tactic.effectType === "international-law" ||
+      tactic.effectType === "gift-boxes"
+    ) {
+      deps.applyTactic(tactic, null, "opponent");
+      return;
+    }
+
+    if (
+      tactic.effectType === "encourage-nap" ||
+      tactic.effectType === "suggest-yoga" ||
+      tactic.effectType === "justice-cocktails" ||
+      tactic.effectType === "catch-phone" ||
+      tactic.effectType === "plant-story" ||
+      tactic.effectType === "whisper-campaign"
+    ) {
+      const unblocked = game.bench.filter(
+        (j) => !(j.id in game.nappingJustices) && !(j.id in game.yogaJustices) && !game.playerShields.includes(j.id),
+      );
+      const target = unblocked.sort((a, b) => (game.leanings[b.id] ?? 0) - (game.leanings[a.id] ?? 0))[0];
+      if (!target) {
+        endOpponentTurn();
+        return;
+      }
+      deps.applyTactic(tactic, target, "opponent");
+      return;
+    }
+
+    if (tactic.effectType === "swap-clerks") {
+      const eligibleMultiTargetJustices = getEligibleMultiTargetJustices(tactic);
+      if (eligibleMultiTargetJustices.length < 2) {
+        endOpponentTurn();
+        return;
+      }
+      const shuffled = deps.shuffle([...eligibleMultiTargetJustices]);
+      game.multiTargetMode = true;
+      game.multiTargetTacticId = tactic.id;
+      game.multiTargetSelections = [shuffled[0].id, shuffled[1].id];
+      deps.applyTactic(tactic, null, "opponent");
+      return;
+    }
+
+    if (tactic.effectType === "betray-friend" || tactic.effectType === "invite-church") {
+      const fallback = available.filter((t) => !["betray-friend", "invite-church", "claim-two", "make-chief"].includes(t.effectType));
+      if (!fallback.length) {
+        endOpponentTurn();
+        return;
+      }
+      deps.applyTactic(fallback[Math.floor(Math.random() * fallback.length)], null, "opponent");
+      return;
+    }
+
+    if (tactic.effectType === "recuse") {
+      const friendlies = game.bench
+        .filter((j) => !game.playerShields.includes(j.id) && (game.leanings[j.id] ?? 0) > gameSettings.abstentionThreshold)
+        .sort((a, b) => (game.leanings[b.id] ?? 0) - (game.leanings[a.id] ?? 0));
+      if (!friendlies.length) {
+        endOpponentTurn();
+        return;
+      }
+      deps.applyTactic(tactic, friendlies[0], "opponent");
+      return;
+    }
+
+    if (tactic.effectType === "shield") {
+      const allies = game.bench.filter((j) => (game.leanings[j.id] ?? 0) < 0);
+      if (!allies.length) {
+        const fallback = available.filter((t) => t.effectType !== "shield" && t.effectType !== "claim-two" && t.effectType !== "make-chief");
+        if (!fallback.length) {
+          endOpponentTurn();
+          return;
+        }
+        const fb = fallback[Math.floor(Math.random() * fallback.length)];
+        deps.applyTactic(fb, null, "opponent");
+        return;
+      }
+      deps.applyTactic(tactic, allies[Math.floor(Math.random() * allies.length)], "opponent");
+      return;
+    }
+
+    if (tactic.effectType === "make-chief") {
+      const candidates = game.bench.filter((j) => j.id !== game.chiefJusticeId && (game.leanings[j.id] ?? 0) < 0);
+      if (!candidates.length) {
+        endOpponentTurn();
+        return;
+      }
+      deps.applyTactic(tactic, candidates[Math.floor(Math.random() * candidates.length)], "opponent");
+      return;
+    }
+
+    const candidates = game.bench.filter((j) => !game.playerShields.includes(j.id));
+    if (!candidates.length) {
+      endOpponentTurn();
+      return;
+    }
+    deps.applyTactic(tactic, candidates[Math.floor(Math.random() * candidates.length)], "opponent");
+  }
+
+  function endOpponentTurn(): void {
+    for (const [idStr, napRound] of Object.entries(game.nappingJustices)) {
+      if (napRound <= game.round) {
+        const id = Number(idStr);
+        delete game.nappingJustices[id];
+      }
+    }
+    for (const [idStr, yogaRound] of Object.entries(game.yogaJustices)) {
+      if (yogaRound <= game.round) {
+        const id = Number(idStr);
+        delete game.yogaJustices[id];
+        game.statMods[id] = {
+          ...(game.statMods[id] ?? {}),
+          empathy: (game.statMods[id]?.empathy ?? 0) + 3,
+          susceptibility: (game.statMods[id]?.susceptibility ?? 0) + 3,
+        };
+      }
+    }
+    ui.opponentThinking = false;
+    game.currentTurn = "player";
+
+    deps.triggerLemonMomentIfDue();
+
+    if (game.skipNextRound) {
+      delete game.skipNextRound;
+      game.round += 2;
+      game.currentTurn = "opponent";
+
+      if (game.round > gameSettings.numberOfRounds) {
+        void deps.trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
+        setTimeout(() => {
+          ui.phase = "verdict";
+        }, 1500);
+        return;
+      }
+
+      ui.opponentThinking = true;
+      setTimeout(() => playOpponentTurn(), 1000);
+      return;
+    }
+
+    if (game.round >= gameSettings.numberOfRounds) {
+      void deps.trackTrialVerdictStats({ isQuickplay: !ui.isCampaignMode });
+      setTimeout(() => {
+        ui.phase = "verdict";
+      }, 1500);
+    } else {
+      game.round++;
+    }
+  }
+
+  return { endPlayerTurn, endOpponentTurn, getEligibleMultiTargetJustices };
+}

--- a/tests/court-turns.spec.ts
+++ b/tests/court-turns.spec.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCourtTurns } from "../src/views/court/ts/_useCourtTurns";
+import type { CampaignState, CourtGameState, Justice, Party, Tactic } from "../src/views/court/ts/_types";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeJustice(id: number, party: Party = "Democrat"): Justice {
+  return {
+    id,
+    name: `Justice ${id}`,
+    image: "",
+    description: "",
+    justiceType: "current",
+    gender: "M",
+    birthYear: 1960,
+    nominatedBy: { id: 100 + id, name: "President", party },
+    religion: "Other",
+    ethnicity: "White",
+    stats: { logic: 5, charisma: 5, empathy: 5, susceptibility: 5, partyLoyalty: 5 },
+    weaknesses: { flattery: 5, bribery: 5, blackmail: 5, threats: 5 },
+  };
+}
+
+function makeTactic(id: number, effectType: Tactic["effectType"] = "sway-one"): Tactic {
+  return {
+    id,
+    name: `Tactic ${id}`,
+    description: "",
+    flavorText: "",
+    cardType: "attack",
+    effectType,
+    basePower: 3,
+  };
+}
+
+function makeGame(justices: Justice[], overrides: Partial<CourtGameState> = {}): CourtGameState {
+  return {
+    bench: justices,
+    currentCase: {
+      id: 1,
+      name: "Test Case",
+      caseType: "fictional",
+      primaryQuestion: "?",
+      prosecution: { name: "P", argument: "Pa", favoredBy: "Democrat" },
+      defendant: { name: "D", argument: "Da", favoredBy: "Republican" },
+    },
+    playerSide: "prosecution",
+    chiefJusticeId: justices[0]?.id ?? null,
+    chiefJusticeHardened: false,
+    deck: [],
+    discardPile: [],
+    playbook: [],
+    claimedCards: [],
+    currentTurn: "player",
+    round: 1,
+    totalRounds: 5,
+    selectedTacticId: null,
+    claimingMode: false,
+    claimedSelections: [],
+    leanings: Object.fromEntries(justices.map((j) => [j.id, 0])),
+    susceptibilityMods: Object.fromEntries(justices.map((j) => [j.id, 0])),
+    playerShields: [],
+    opponentShields: [],
+    recusedJustices: [],
+    nappingJustices: {},
+    yogaJustices: {},
+    draggedJustices: [],
+    statMods: {},
+    weaknessMods: {},
+    religionOverrides: {},
+    multiTargetMode: false,
+    multiTargetSelections: [],
+    multiTargetTacticId: null,
+    makeChiefPlayedThisTrial: false,
+    suggestRetirementTargets: [],
+    keepCrownActivated: false,
+    reframeStanceMode: false,
+    reframeStanceChoices: [],
+    reframeStanceTacticId: null,
+    reframeStanceSelection: null,
+    ...overrides,
+  };
+}
+
+function makeUi(overrides: Partial<{ phase: string; isCampaignMode: boolean; opponentThinking: boolean; opponentHighlightedCardId: number | null }> = {}) {
+  return { phase: "playing", isCampaignMode: false, opponentThinking: false, opponentHighlightedCardId: null, ...overrides };
+}
+
+function makeDeps() {
+  return {
+    trackTrialVerdictStats: vi.fn().mockResolvedValue(undefined),
+    applyTactic: vi.fn(),
+    shuffle: <T>(arr: T[]) => [...arr],
+    triggerLemonMomentIfDue: vi.fn(),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useCourtTurns", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // ── getEligibleMultiTargetJustices ────────────────────────────
+
+  describe("getEligibleMultiTargetJustices", () => {
+    it("returns all bench justices for swap-clerks when none are napping or recused", () => {
+      const justices = [makeJustice(1), makeJustice(2), makeJustice(3)];
+      const game = makeGame(justices);
+      const { getEligibleMultiTargetJustices } = useCourtTurns(game, { data: null }, makeUi(), makeDeps());
+      const tactic = makeTactic(1, "swap-clerks");
+      expect(getEligibleMultiTargetJustices(tactic)).toHaveLength(3);
+    });
+
+    it("excludes napping justices from swap-clerks targets", () => {
+      const justices = [makeJustice(1), makeJustice(2), makeJustice(3)];
+      const game = makeGame(justices, { nappingJustices: { 2: 3 } });
+      const { getEligibleMultiTargetJustices } = useCourtTurns(game, { data: null }, makeUi(), makeDeps());
+      const tactic = makeTactic(1, "swap-clerks");
+      const eligible = getEligibleMultiTargetJustices(tactic);
+      expect(eligible).toHaveLength(2);
+      expect(eligible.every((j) => j.id !== 2)).toBe(true);
+    });
+
+    it("excludes recused justices from swap-clerks targets", () => {
+      const justices = [makeJustice(1), makeJustice(2), makeJustice(3)];
+      const game = makeGame(justices, { recusedJustices: [3] });
+      const { getEligibleMultiTargetJustices } = useCourtTurns(game, { data: null }, makeUi(), makeDeps());
+      const tactic = makeTactic(1, "swap-clerks");
+      const eligible = getEligibleMultiTargetJustices(tactic);
+      expect(eligible).toHaveLength(2);
+      expect(eligible.every((j) => j.id !== 3)).toBe(true);
+    });
+
+    it("returns empty array for non-swap-clerks tactics", () => {
+      const justices = [makeJustice(1), makeJustice(2)];
+      const game = makeGame(justices);
+      const { getEligibleMultiTargetJustices } = useCourtTurns(game, { data: null }, makeUi(), makeDeps());
+      expect(getEligibleMultiTargetJustices(makeTactic(1, "sway-all"))).toHaveLength(0);
+    });
+
+    it("returns empty array for null tactic", () => {
+      const game = makeGame([makeJustice(1)]);
+      const { getEligibleMultiTargetJustices } = useCourtTurns(game, { data: null }, makeUi(), makeDeps());
+      expect(getEligibleMultiTargetJustices(null)).toHaveLength(0);
+    });
+  });
+
+  // ── endOpponentTurn ───────────────────────────────────────────
+
+  describe("endOpponentTurn", () => {
+    it("increments round when below max", () => {
+      const game = makeGame([makeJustice(1)], { round: 3, totalRounds: 5 });
+      const ui = makeUi({ opponentThinking: true });
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, ui, makeDeps());
+      endOpponentTurn();
+      expect(game.round).toBe(4);
+    });
+
+    it("does not increment round at max rounds — triggers verdict instead", () => {
+      const game = makeGame([makeJustice(1)], { round: 5, totalRounds: 5 });
+      const ui = makeUi({ opponentThinking: true, phase: "playing" });
+      const deps = makeDeps();
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, ui, deps);
+      endOpponentTurn();
+      expect(deps.trackTrialVerdictStats).toHaveBeenCalledWith({ isQuickplay: true });
+      vi.runAllTimers();
+      expect(ui.phase).toBe("verdict");
+      expect(game.round).toBe(5);
+    });
+
+    it("clears opponent thinking flag", () => {
+      const game = makeGame([makeJustice(1)]);
+      const ui = makeUi({ opponentThinking: true });
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, ui, makeDeps());
+      endOpponentTurn();
+      expect(ui.opponentThinking).toBe(false);
+    });
+
+    it("triggers lemon moment check", () => {
+      const game = makeGame([makeJustice(1)]);
+      const deps = makeDeps();
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, makeUi(), deps);
+      endOpponentTurn();
+      expect(deps.triggerLemonMomentIfDue).toHaveBeenCalled();
+    });
+
+    it("wakes napping justices whose nap ends this round", () => {
+      const game = makeGame([makeJustice(1), makeJustice(2)], {
+        round: 3,
+        nappingJustices: { 1: 3, 2: 5 },
+      });
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, makeUi({ opponentThinking: true }), makeDeps());
+      endOpponentTurn();
+      expect(game.nappingJustices[1]).toBeUndefined();
+      expect(game.nappingJustices[2]).toBe(5);
+    });
+
+    it("applies empathy and susceptibility buffs when yoga justice wakes up", () => {
+      const game = makeGame([makeJustice(1)], {
+        round: 3,
+        yogaJustices: { 1: 3 },
+        statMods: {},
+      });
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, makeUi({ opponentThinking: true }), makeDeps());
+      endOpponentTurn();
+      expect(game.yogaJustices[1]).toBeUndefined();
+      expect(game.statMods[1]?.empathy).toBe(3);
+      expect(game.statMods[1]?.susceptibility).toBe(3);
+    });
+
+    it("handles skipNextRound — advances 2 rounds and re-triggers opponent turn", () => {
+      const game = makeGame([makeJustice(1)], { round: 2, skipNextRound: true });
+      const ui = makeUi({ opponentThinking: true });
+      const deps = makeDeps();
+      // put a sway-all tactic in playbook so playOpponentTurn has something to do
+      game.playbook = [makeTactic(1, "sway-all")];
+      const { endOpponentTurn } = useCourtTurns(game, { data: null }, ui, deps);
+      endOpponentTurn();
+      expect(game.skipNextRound).toBeUndefined();
+      expect(game.round).toBe(4);
+      expect(game.currentTurn).toBe("opponent");
+    });
+  });
+
+  // ── endPlayerTurn ─────────────────────────────────────────────
+
+  describe("endPlayerTurn", () => {
+    it("clears doubleTapActive and stays on player turn", () => {
+      const game = makeGame([makeJustice(1)]);
+      const campaign = { data: { doubleTapActive: true } as unknown as CampaignState };
+      const ui = makeUi();
+      const { endPlayerTurn } = useCourtTurns(game, campaign, ui, makeDeps());
+      endPlayerTurn();
+      expect(campaign.data!.doubleTapActive).toBe(false);
+      expect(game.currentTurn).toBe("player");
+      expect(ui.opponentThinking).toBe(false);
+    });
+
+    it("hands off to opponent when no double-tap is active", () => {
+      const game = makeGame([makeJustice(1)]);
+      const ui = makeUi();
+      const { endPlayerTurn } = useCourtTurns(game, { data: null }, ui, makeDeps());
+      endPlayerTurn();
+      expect(game.currentTurn).toBe("opponent");
+      expect(ui.opponentThinking).toBe(true);
+    });
+
+    it("handles skipNextRound — advances 2 rounds and stays on player", () => {
+      const game = makeGame([makeJustice(1)], { round: 2, skipNextRound: true });
+      const ui = makeUi();
+      const { endPlayerTurn } = useCourtTurns(game, { data: null }, ui, makeDeps());
+      endPlayerTurn();
+      expect(game.skipNextRound).toBeUndefined();
+      expect(game.round).toBe(4);
+      expect(game.currentTurn).toBe("player");
+    });
+
+    it("skipNextRound triggers verdict when it pushes past max rounds", () => {
+      const game = makeGame([makeJustice(1)], { round: 4, totalRounds: 5, skipNextRound: true });
+      const ui = makeUi({ phase: "playing" });
+      const deps = makeDeps();
+      const { endPlayerTurn } = useCourtTurns(game, { data: null }, ui, deps);
+      endPlayerTurn();
+      expect(deps.trackTrialVerdictStats).toHaveBeenCalledWith({ isQuickplay: true });
+      vi.runAllTimers();
+      expect(ui.phase).toBe("verdict");
+    });
+  });
+});


### PR DESCRIPTION
This closes #241

## Summary

- **Court.vue reduced from 1,560 → 986 lines** (37%) by extracting three composables into the `ts/` directory
- Lint and TypeScript both pass clean with no new errors introduced

## New files

| File | Contents |
|------|----------|
| `_useCourtComputeds.ts` | All 18 computed refs (verdict, bench overview, tally display, verdict/ruling display, justice targetings, bench label, preview preset, etc.) |
| `_useCourtHelpers.ts` | Stateful UI helpers (`voteMeterStyle`, `verdictJusticeBarStyle`, `justiceVoteHistory`) + 8 pure-function exports (`getKeyStats`, `justiceTypeLabel`, `sideStanceTags`, `targetLabel`, `voteLabel`, `justiceImageUrl`, `presidentImageUrl`, `justiceHints`) |
| `_useCourtTurns.ts` | Turn flow and opponent AI (`endPlayerTurn`, `endOpponentTurn`, `playOpponentTurn`, `getEligibleMultiTargetJustices`) |

## Design notes

- **Lemon moment stays in Court.vue** — `triggerLemonMomentIfDue` is passed as a callback to `useCourtTurns` rather than imported into the composable. Plain `.ts` files can't import `.vue` components without `vue-tsc`, so the toast UI stays in the Vue file.
- **`applyTactic` ↔ turn functions circular dep** — broken via a closure: `applyTactic` is a function declaration (hoisted) so the callback `(t, j, a) => applyTactic(t, j, a)` passed to `useCourtTurns` resolves correctly at call time.
- **ESLint false positives** — the base `no-unused-vars` rule incorrectly flags TypeScript interface method parameter names. Suppressed with a targeted `eslint-disable` block (same pre-existing pattern as `_campaignManager.ts`).