### PR TITLE
#268 Add three new dark deeds

### DIFF
--- a/src/views/megachurch/Megachurch.pug
+++ b/src/views/megachurch/Megachurch.pug
@@ -71,15 +71,15 @@
 
   WorshopZoneBanner(
     v-if="ui.worshopZone.showBanner && my.church.isFounded"
-    @show-workshop-zone="onBannerAccepted"
+    @show-worshop-zone="onBannerAccepted"
     @close="() => ui.worshopZone.showBanner = false"
   )
 
   WorshopZone(
     v-if="ui.worshopZone.isOpen"
     @close="closeWorshopZone"
-    @purchase="handleWorkshopPurchase"
-  ) 
+    @purchase="handleWorshopPurchase"
+  )
 
   EternalLegacyShop(
     v-if="ui.eternalLegacyShop.isOpen"

--- a/src/views/megachurch/Megachurch.vue
+++ b/src/views/megachurch/Megachurch.vue
@@ -111,7 +111,7 @@
     closeSterlingInterface,
     showWorshopZone,
     closeWorshopZone,
-    handleWorkshopPurchase,
+    handleWorshopPurchase,
     onBannerAccepted,
     openWorshopZoneForSeraph,
     dismissSeraphNag,
@@ -352,7 +352,7 @@
           });
           break;
 
-        case "workshopPurchase":
+        case "worshopPurchase":
           if (data.type === "merch") {
             const merchRef = doc(db, `stats/megachurch/merch/${data.name}`);
             const merchSnap = await getDoc(merchRef);

--- a/src/views/megachurch/components/EternalLegacy/EternalLegacyShop.pug
+++ b/src/views/megachurch/components/EternalLegacy/EternalLegacyShop.pug
@@ -54,20 +54,20 @@ Teleport(to="body")
                 .purchased-indicator(v-else)
                   | Owned
 
-        // Dark Deeds Tab  
+        // Dark Deeds Tab
         .under-the-table-tab(v-if="activeTab === 'darkDeeds'")
           .tab-header
-            p.tab-description 
-              | Sometimes prosperity requires... creative arrangements. 
-              | All of these opportunities provide  
+            p.tab-description
+              | Sometimes prosperity requires... creative arrangements.
+              | All of these opportunities provide
               strong significant risks
               |  but substantial rewards.
-              
+
           .items-grid
             .item-card(
               v-for="item in gameSettings.eternalLegacy.shop.darkDeeds"
               :key="item.id"
-              :class="{ purchased: my.eternalLegacy.purchasedItems.includes(item.id), affordable: my.money >= item.cost, dangerous: true }"
+              :class="{ purchased: item.id !== 'religious-artifacts' && my.eternalLegacy.darkDeeds.some(p => p.id === item.id), affordable: my.money >= item.cost, dangerous: true }"
             )
               .item-details
                 h4 {{ item.name }}
@@ -76,17 +76,28 @@ Teleport(to="body")
                   .cost(v-if="item.cost") {{ dollars(item.cost) }}
                   .heat(v-if="item.heat > 0") +{{ item.heat }} heat
                   .heat(v-if="item.cutIncreasase") +{{ item.cutIncreasase }}% increase to Sterling's cut
-                  .heat(v-if="item.id === 'sterling-cut'") 20% reduction in heat increase
+                  .heat(v-if="item.id === 'sterling-bribe'") −3 heat/day
+                  .heat(v-if="item.dailyHeat") +{{ item.dailyHeat }} heat/day
+                  .heat(v-if="item.dailyMoney") +{{ dollars(item.dailyMoney) }}/day income
+                  .heat(v-if="item.id === 'tariff-evasion'") 25% off Worshop Zone items · +{{ gameSettings.eternalLegacy.darkDeedConfig.tariffEvasion.shoppingDayHeat }} heat on shopping days
+                  .heat(v-if="item.id === 'religious-artifacts' && my.eternalLegacy.darkDeeds.some(p => p.id === 'religious-artifacts')")
+                    | {{ my.eternalLegacy.darkDeeds.find(p => p.id === 'religious-artifacts').purchases?.length || 0 }} artifact(s) acquired
               .item-actions
-                template(v-if="item.id === 'sterling-cut' && !my.eternalLegacy.sterlingAlive")
+                template(v-if="item.id === 'sterling-bribe' && !my.eternalLegacy.sterlingAlive")
                   .purchased-indicator
                     | 💀 Sterling is dead.
+                template(v-else-if="item.id === 'religious-artifacts'")
+                  button.purchase-btn.dangerous(
+                    :disabled="my.money < item.cost"
+                    @click="purchaseItem(item, 'darkDeeds')"
+                  )
+                    | {{ my.money >= item.cost ? 'Do The Deed' : 'Too Expensive' }}
                 template(v-else)
                   button.purchase-btn.dangerous(
                     v-if="!my.eternalLegacy.darkDeeds.some(p => p.id === item.id)"
                     :disabled="my.money < item.cost"
                     @click="purchaseItem(item, 'darkDeeds')"
-                  ) 
+                  )
                     | {{ my.money >= item.cost ? 'Do The Deed' : 'Too Expensive' }}
                   .purchased-indicator(v-else)
                     | ✅ Done

--- a/src/views/megachurch/components/EternalLegacy/LegacyStatus.pug
+++ b/src/views/megachurch/components/EternalLegacy/LegacyStatus.pug
@@ -71,8 +71,12 @@
           )
             .deed-icon 👹
             .deed-info
-              .deed-name(v-if="deed.id === 'kill-sterling' || deed.id === 'consultation-tony'") You killed Sterling
-              .deed-name(v-else-if="deed.id === 'sterling-bribe' || deed.id === 'sterling-cut'") You got Sterling to bribe the cops
+              .deed-name(v-if="deed.id === 'kill-sterling'") You killed Sterling
+              .deed-name(v-else-if="deed.id === 'sterling-bribe'") You got Sterling to bribe the cops
+              .deed-name(v-else-if="deed.id === 'tax-haven'") You became a tax haven
+              .deed-name(v-else-if="deed.id === 'tariff-evasion'") You established a China import network
+              .deed-name(v-else-if="deed.id === 'religious-artifacts'")
+                | You've acquired {{ deed.purchases?.length || 0 }} religious artifact(s)
               //.deed-effect {{ deed.effect }}
 
     // Empty State

--- a/src/views/megachurch/components/WorshopZone/WorshopZone.scss
+++ b/src/views/megachurch/components/WorshopZone/WorshopZone.scss
@@ -1,6 +1,6 @@
 @import "../../scss/variables";
 
-.workshop-zone-overlay {
+.worshop-zone-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -13,7 +13,7 @@
   align-items: center;
 }
 
-.workshop-zone {
+.worshop-zone {
   width: 800px;
   height: 600px;
   background: $retroGray;

--- a/src/views/megachurch/components/WorshopZone/WorshopZone.vue
+++ b/src/views/megachurch/components/WorshopZone/WorshopZone.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="workshop-zone-overlay" @click="closeWorkshop">
-    <div class="workshop-zone" @click.stop>
+  <div class="worshop-zone-overlay" @click="closeWorshop">
+    <div class="worshop-zone" @click.stop>
       <!-- IE6 Browser Chrome -->
       <div class="browser-chrome">
         <div class="title-bar">
@@ -8,7 +8,7 @@
           <div class="window-controls">
             <button class="minimize-btn">_</button>
             <button class="maximize-btn">□</button>
-            <button class="close-btn" @click="closeWorkshop">×</button>
+            <button class="close-btn" @click="closeWorshop">×</button>
           </div>
         </div>
 
@@ -577,7 +577,7 @@
     return my.church.location.religions.map((locReligion) => religions.find((r) => r.id === locReligion.id)).filter(Boolean);
   });
 
-  function closeWorkshop() {
+  function closeWorshop() {
     emit("close");
   }
 
@@ -600,7 +600,9 @@
   function getMerchCost(merchType: MerchTypes) {
     const quantity = merchQuantities.value[merchType];
     const costPerItem = gameSettings.church.merch[merchType].cost;
-    const itemCost = quantity * costPerItem;
+    const hasTariffEvasion = my.eternalLegacy.darkDeeds.some(d => d.id === "tariff-evasion");
+    const discount = hasTariffEvasion ? gameSettings.eternalLegacy.darkDeedConfig.tariffEvasion.discount : 0;
+    const itemCost = quantity * costPerItem * (1 - discount);
     return itemCost + shippingCost;
   }
 
@@ -610,6 +612,7 @@
 
     if (my.money >= cost) {
       my.money -= cost;
+      my.eternalLegacy.worshopPurchasedToday = true;
 
       let merchName = "";
       if (merchType === "holyWater") {

--- a/src/views/megachurch/components/WorshopZone/WorshopZoneBanner.vue
+++ b/src/views/megachurch/components/WorshopZone/WorshopZoneBanner.vue
@@ -44,7 +44,7 @@
 <script setup lang="ts">
   const emit = defineEmits<{
     close: [];
-    "show-workshop-zone": [];
+    "show-worshop-zone": [];
   }>();
 
   function closeBanner() {
@@ -52,7 +52,7 @@
   }
 
   function openWorshopZone() {
-    emit("show-workshop-zone");
+    emit("show-worshop-zone");
   }
 </script>
 

--- a/src/views/megachurch/pug/_sermon-results.pug
+++ b/src/views/megachurch/pug/_sermon-results.pug
@@ -186,7 +186,7 @@ section.sermon-results(v-if="ui.view === 'sermon-results'")
         .van-tooltip(v-if="my.chats.sterling.daysWithVan < 1") Drive overnight. #[br] (The Plug will find you)
         button.van(@click="ui.view = 'place'") #[span 🚐] Get In The Van
       button.sterling(v-if="my.chats.sterling.hasContacted && my.eternalLegacy.sterlingAlive" @click="openSterlingInterface()") 📱 Sterling Silver
-      button.workshop-zone(v-if="my.church.isFounded" @click="showWorshopZone") 💻 Da Worshop Zone
+      button.worshop-zone(v-if="my.church.isFounded" @click="showWorshopZone") 💻 Da Worshop Zone
       button.eternal-legacy(v-if="my.eternalLegacy.isActive" @click="showEternalLegacyShop") 💻 Eternal Legacy
       button.submit(@click="handleNextDayClick()") Next Day.
 

--- a/src/views/megachurch/ts/_types.ts
+++ b/src/views/megachurch/ts/_types.ts
@@ -3,6 +3,7 @@ import {
   EternalLegacyDarkDeed,
   EternalLegacyBibleVerse,
   EternalLegacyCelebrity,
+  ArtifactPurchase,
 } from "./variables/_eternalLegacy";
 
 // ================= GENERAL TYPES =================
@@ -429,6 +430,21 @@ export interface GameSettings {
       celebrities: EternalLegacyCelebrity[];
     };
     bibleVerses: EternalLegacyBibleVerse[];
+    darkDeedConfig: {
+      taxHaven: {
+        dailyHeat: number;
+        dailyMoney: number;
+      };
+      religiousArtifacts: {
+        heat: number;
+        cost: number;
+        tiers: { threshold: number; mammon: number }[];
+      };
+      tariffEvasion: {
+        discount: number;
+        shoppingDayHeat: number;
+      };
+    };
   };
 }
 
@@ -544,6 +560,7 @@ export interface My {
     sterlingCutModifier: number; // Additional percentage points added to Sterling's cut
     sterlingAlive: boolean;
     friendedCelebrityIds: string[]; // IDs of celebrities that have been friended before (prevents re-friending)
+    worshopPurchasedToday: boolean; // True if any Worshop Zone purchase was made today; used by Tariff Evasion heat check
   };
   gameOverCause: null | "drug overdose" | "prison"; // If endgame is triggered (not null), what caused game over
 }

--- a/src/views/megachurch/ts/_useEternalLegacy.ts
+++ b/src/views/megachurch/ts/_useEternalLegacy.ts
@@ -2,6 +2,8 @@ import { gameSettings } from "./variables/_gameSettings";
 import { religions } from "./_religions";
 import { soundWhoopsYoureDead, soundInPrison } from "./variables/_sounds";
 import type { My, UI } from "./_types";
+import { randomNumber, randomFrom } from "../../../shared/ts/_functions";
+import { artifactNames } from "./variables/_eternalLegacy";
 
 /* eslint-disable no-unused-vars */
 interface ToastApi {
@@ -48,6 +50,14 @@ export function useEternalLegacy({
   }
 
   function handleEternalLegacyPurchase({ item, category }) {
+    if (item.id === "religious-artifacts") {
+      const result = purchaseReligiousArtifacts();
+      if (result) {
+        toast.warning(`🏺 ${result.artifactName} acquired. +${result.mammon} mammon. Probably fake. 🔥 +${gameSettings.eternalLegacy.darkDeedConfig.religiousArtifacts.heat} heat.`);
+      }
+      return;
+    }
+
     if (my.money < item.cost) {
       toast.error("Insufficient funds for this divine acquisition.");
       return;
@@ -64,6 +74,11 @@ export function useEternalLegacy({
         toast.warning(
           "You have already established a friendship with this celebrity in the past.",
         );
+        return;
+      }
+    } else if (category === "darkDeeds") {
+      if (my.eternalLegacy.darkDeeds.some((d) => d.id === item.id)) {
+        toast.warning("You already own this item.");
         return;
       }
     } else {
@@ -101,11 +116,7 @@ export function useEternalLegacy({
 
       // Apply specific mechanics based on item ID
       switch (item.id) {
-        case "shredder":
-          // Slows heat gain - could be implemented as a modifier
-          break;
-
-        case "sterling-cut":
+        case "sterling-bribe":
           // Increase Sterling's cut permanently
           my.eternalLegacy.sterlingCutModifier += item.cutIncreasase; // Increase Sterling's cut.
           gameSettings.eternalLegacy.heat.dailyBaseIncrease -= 3;
@@ -114,25 +125,28 @@ export function useEternalLegacy({
           );
           break;
 
-        case "tax-attorney":
-          // Reduce Sterling payments but increase heat and scandal
-          toast.success(
-            `${item.name}: Legal protection secured. Sterling's leverage reduced, but congregation scandalized.`,
-          );
-          break;
-
-        case "consultation-tony":
+        case "kill-sterling":
           // Eliminate Sterling but massive heat increase
           my.eternalLegacy.sterlingAlive = false;
           toast.error(
             `${item.name}: Sterling has been... permanently removed. Heat increased by ${item.heat}`,
           );
           break;
+
+        case "tax-haven":
+          toast.warning(`${item.name}: The IRS is going to love this. +${gameSettings.eternalLegacy.darkDeedConfig.taxHaven.dailyMoney}/day income, +${gameSettings.eternalLegacy.darkDeedConfig.taxHaven.dailyHeat} heat/day.`);
+          break;
+
+        case "tariff-evasion":
+          toast.success(`${item.name}: Your guy knows a guy. All Worshop Zone merchandise is now 25% cheaper — but expect heat every day you shop.`);
+          break;
       }
 
-      toast.warning(
-        `🔥 Heat increased by ${item.heat}! Current: ${my.eternalLegacy.heat}/${gameSettings.eternalLegacy.heat.max}`,
-      );
+      if (item.heat > 0) {
+        toast.warning(
+          `🔥 Heat increased by ${item.heat}! Current: ${my.eternalLegacy.heat}/${gameSettings.eternalLegacy.heat.max}`,
+        );
+      }
     } else if (category === "celebrities") {
       // Handle celebrity friendship acquisition
       const celebrity = { ...item }; // Make a copy to avoid reference issues
@@ -280,6 +294,39 @@ export function useEternalLegacy({
     if (my.eternalLegacy.heat >= gameSettings.eternalLegacy.heat.max) {
       triggerEndGame("prison");
     }
+  }
+
+  function purchaseReligiousArtifacts() {
+    const config = gameSettings.eternalLegacy.darkDeedConfig.religiousArtifacts;
+    if (my.money < config.cost) {
+      toast.error("You can't afford this. Even the terrorist artifact network expects payment.");
+      return null;
+    }
+
+    my.money -= config.cost;
+
+    const roll = randomNumber(0, 100);
+    const tier = config.tiers.find(t => roll < t.threshold) ?? config.tiers[config.tiers.length - 1];
+    const artifactName = randomFrom(artifactNames);
+
+    my.eternalLegacy.totalMammon += tier.mammon;
+    updateHeat(config.heat);
+
+    const existingDeed = my.eternalLegacy.darkDeeds.find(d => d.id === "religious-artifacts");
+    if (existingDeed) {
+      existingDeed.purchases = existingDeed.purchases ?? [];
+      existingDeed.purchases.push({ day: my.daysPlayed, mammon: tier.mammon, artifactName });
+    } else {
+      const deedDef = gameSettings.eternalLegacy.shop.darkDeeds.find(d => d.id === "religious-artifacts")!;
+      my.eternalLegacy.darkDeeds.push({
+        ...deedDef,
+        dayPurchased: my.daysPlayed,
+        purchases: [{ day: my.daysPlayed, mammon: tier.mammon, artifactName }],
+      });
+    }
+
+    logGameplayToFirebase("eternalLegacyPurchase", { name: artifactName, collection: "darkDeeds" });
+    return { artifactName, mammon: tier.mammon };
   }
 
   // === Church Inventory Functions ===
@@ -559,6 +606,7 @@ export function useEternalLegacy({
     showEternalLegacyShop,
     closeEternalLegacyShop,
     handleEternalLegacyPurchase,
+    purchaseReligiousArtifacts,
     checkEternalLegacyTrigger,
     triggerEternalLegacy,
     playEternalLegacyVoicemail,

--- a/src/views/megachurch/ts/_useEternalLegacy.ts
+++ b/src/views/megachurch/ts/_useEternalLegacy.ts
@@ -325,7 +325,7 @@ export function useEternalLegacy({
       });
     }
 
-    logGameplayToFirebase("eternalLegacyPurchase", { name: artifactName, collection: "darkDeeds" });
+    logGameplayToFirebase("eternalLegacyPurchase", { name: "Smuggle Religious Artifacts", collection: "darkDeeds" });
     return { artifactName, mammon: tier.mammon };
   }
 

--- a/src/views/megachurch/ts/_useSpiceDayHelpers.ts
+++ b/src/views/megachurch/ts/_useSpiceDayHelpers.ts
@@ -177,9 +177,9 @@ export function useSpiceDayHelpers(
     ui.churchInventory.isOpen = false; // Auto-close ChurchInventory when WorshopZone closes
   }
 
-  function handleWorkshopPurchase(purchaseData: any) {
-    // Log workshop purchases to Firebase
-    logGameplayToFirebase("workshopPurchase", purchaseData);
+  function handleWorshopPurchase(purchaseData: any) {
+    // Log worshop purchases to Firebase
+    logGameplayToFirebase("worshopPurchase", purchaseData);
   }
 
   function onBannerAccepted() {
@@ -408,7 +408,23 @@ export function useSpiceDayHelpers(
       if (my.eternalLegacy.heat >= gameSettings.eternalLegacy.heat.max) {
         return; // Endgame triggered
       }
+
+      // Tax Haven: daily heat and income
+      const taxHavenDeed = my.eternalLegacy.darkDeeds.find(d => d.id === "tax-haven");
+      if (taxHavenDeed) {
+        callbacks.updateHeat(gameSettings.eternalLegacy.darkDeedConfig.taxHaven.dailyHeat);
+        if (my.eternalLegacy.heat >= gameSettings.eternalLegacy.heat.max) return;
+        my.money += gameSettings.eternalLegacy.darkDeedConfig.taxHaven.dailyMoney;
+      }
+
+      // Tariff Evasion: heat on days the player shopped
+      const tariffEvasionDeed = my.eternalLegacy.darkDeeds.find(d => d.id === "tariff-evasion");
+      if (tariffEvasionDeed && my.eternalLegacy.worshopPurchasedToday) {
+        callbacks.updateHeat(gameSettings.eternalLegacy.darkDeedConfig.tariffEvasion.shoppingDayHeat);
+        if (my.eternalLegacy.heat >= gameSettings.eternalLegacy.heat.max) return;
+      }
     }
+    my.eternalLegacy.worshopPurchasedToday = false;
 
     // Calculate pending addiction BEFORE resetting spice consumption
     resetDailySpice();
@@ -510,7 +526,7 @@ export function useSpiceDayHelpers(
     closePlugInterface,
     showWorshopZone,
     closeWorshopZone,
-    handleWorkshopPurchase,
+    handleWorshopPurchase,
     onBannerAccepted,
     openWorshopZoneForSeraph,
     dismissSeraphNag,

--- a/src/views/megachurch/ts/variables/_eternalLegacy.ts
+++ b/src/views/megachurch/ts/variables/_eternalLegacy.ts
@@ -9,6 +9,12 @@ export interface EternalLegacyShopItem {
   dayPurchased?: number; // Day the deed was purchased
 }
 
+export interface ArtifactPurchase {
+  day: number;
+  mammon: number;
+  artifactName: string;
+}
+
 export interface EternalLegacyDarkDeed {
   id: string;
   name: string;
@@ -17,6 +23,9 @@ export interface EternalLegacyDarkDeed {
   cutIncreasase?: number; // Permanent increase to Sterling's cut
   effect: string;
   dayPurchased?: number; // Day the deed was purchased
+  dailyHeat?: number;
+  dailyMoney?: number;
+  purchases?: ArtifactPurchase[];
 }
 
 export interface EternalLegacyBibleVerse {
@@ -113,10 +122,57 @@ export const eternalLegacyDarkDeeds: EternalLegacyDarkDeed[] = [
     id: "kill-sterling",
     name: "Kill Sterling",
     cost: 1500,
-    heat: 15,
+    heat: 25,
     effect:
       "Pay someone inside the prison to arrange for an accident to happen to Sterling Silver. He will no longer take a cut of your income or bribe authorities, which will hasten their investigation on you.",
   },
+  {
+    id: "tax-haven",
+    name: "Become A Tax Haven",
+    cost: 2500,
+    heat: 0,
+    dailyHeat: 3,
+    dailyMoney: 500,
+    effect:
+      "Extend your church's tax-exempt status to other companies looking to avoid paying taxes. You will file their daily profits as yours, for a fee. The feds will notice — eventually.",
+  },
+  {
+    id: "tariff-evasion",
+    name: "Establish China Import Network",
+    cost: 0,
+    heat: 0,
+    effect:
+      "You know a guy who knows a guy. From now on, all Worshop Zone merchandise arrives via a certain import channel that doesn't ask too many questions — and saves you 25% on every order. On any day you place an order, expect some extra federal attention by morning.",
+  },
+  {
+    id: "religious-artifacts",
+    name: "Smuggle Religious Artifacts",
+    cost: 3500,
+    heat: 10,
+    purchases: [],
+    effect:
+      "Purchase religious artifacts through very suspicious means. The artifacts will probably be fake — but how convincing are they? You can trust the terrorist artifact network, can't you?",
+  },
+];
+
+export const artifactNames: string[] = [
+  "Splinter of the True Cross",
+  "Fragment of the Holy Grail (Unverified)",
+  "Shroud of Turin Swatch (Unsigned)",
+  "Lost Ark Interior Hinge",
+  "Goliath's Molar",
+  "Burning Bush Ash (Sealed, Do Not Open)",
+  "Lot's Wife's Elbow (Pillar of Salt)",
+  "Staff of Moses (Handle End)",
+  "David's Sling (Pre-Giant Encounter)",
+  "Solomon's Temple Cornerstone Chip",
+  "Crown of Thorns Twig",
+  "Manna (Best Before 1200 BCE)",
+  "Elijah's Chariot Wheel Spoke",
+  "Noah's Ark Plank (One of Many)",
+  "Tower of Babel Brick",
+  "Jonah's Whale Tooth",
+  "Original Ten Commandments Fragment (Stone)",
 ];
 
 export const eternalLegacyBibleVerses: EternalLegacyBibleVerse[] = [

--- a/src/views/megachurch/ts/variables/_eternalLegacy.ts
+++ b/src/views/megachurch/ts/variables/_eternalLegacy.ts
@@ -121,7 +121,7 @@ export const eternalLegacyDarkDeeds: EternalLegacyDarkDeed[] = [
   {
     id: "kill-sterling",
     name: "Kill Sterling",
-    cost: 1500,
+    cost: 1800,
     heat: 25,
     effect:
       "Pay someone inside the prison to arrange for an accident to happen to Sterling Silver. He will no longer take a cut of your income or bribe authorities, which will hasten their investigation on you.",
@@ -129,10 +129,10 @@ export const eternalLegacyDarkDeeds: EternalLegacyDarkDeed[] = [
   {
     id: "tax-haven",
     name: "Become A Tax Haven",
-    cost: 2500,
+    cost: 1500,
     heat: 0,
     dailyHeat: 3,
-    dailyMoney: 500,
+    dailyMoney: 750,
     effect:
       "Extend your church's tax-exempt status to other companies looking to avoid paying taxes. You will file their daily profits as yours, for a fee. The feds will notice — eventually.",
   },

--- a/src/views/megachurch/ts/variables/_gameSettings.ts
+++ b/src/views/megachurch/ts/variables/_gameSettings.ts
@@ -176,6 +176,25 @@ export const gameSettings = reactive<GameSettings>({
       dailyBaseIncrease: 9, // Base daily heat increase
       earningsMultiplier: 0.01, // Heat increase per dollar earned
     },
+    darkDeedConfig: {
+      taxHaven: {
+        dailyHeat: 3,
+        dailyMoney: 500,
+      },
+      religiousArtifacts: {
+        heat: 10,
+        cost: 3500,
+        tiers: [
+          { threshold: 60, mammon: 125 },
+          { threshold: 90, mammon: 175 },
+          { threshold: 100, mammon: 250 },
+        ],
+      },
+      tariffEvasion: {
+        discount: 0.25,
+        shoppingDayHeat: 5,
+      },
+    },
     shop: {
       mammonItems: eternalLegacyShopItems,
       darkDeeds: eternalLegacyDarkDeeds,

--- a/src/views/megachurch/ts/variables/_my.ts
+++ b/src/views/megachurch/ts/variables/_my.ts
@@ -189,6 +189,7 @@ export const my = reactive<My>({
     sterlingCutModifier: 0,
     sterlingAlive: true,
     friendedCelebrityIds: [], // Track celebrity IDs that have been friended before
+    worshopPurchasedToday: false,
   },
   gameOverCause: null,
 });


### PR DESCRIPTION
This closes #268

## Summary

- **Tax Haven** — permanent one-time deed ($2,500). Files other companies' profits as yours for a fee: +$500/day income, +3 heat/day ongoing.
- **Religious Artifacts** — repeatable deed ($3,500/use, +10 heat). Rolls for mammon from a pool of 17 artifact names; three quality tiers: 125/175/250 mammon at 60/30/10% odds. Flavor: "You can trust the terrorist artifact network, can't you?"
- **Tariff Evasion** — permanent one-time deed ($0). Establishes a China import network: 25% off all Worshop Zone purchases, +5 heat on any day the player shops.

**Also in this PR:**
- Kill Sterling heat bumped 15 → 25 (better reflects removing Sterling's cut AND accelerating the investigation)
- Fixed stale switch case IDs (`sterling-cut` → `sterling-bribe`, `consultation-tony` → `kill-sterling`) — existing deed mechanics were silently not firing
- Fixed dark deed "already purchased" guard in `handleEternalLegacyPurchase` (was checking `purchasedItems` instead of `darkDeeds`)
- Renamed all `Workshop` spellings to `Worshop` across function names, CSS classes, Vue event names, and Firebase event strings to match the store's intentional pun

## Related issues filed

- #269 — Remove flat shipping cost from Worshop Zone
- #270 — Daily mammon trickle dark deed (TBD design)

## Test plan

- [ ] Purchase Tax Haven → appears in deed list; each new day heat increases by 3 and money increases by $500
- [ ] Purchase Religious Artifacts multiple times → repeatable, money deducted, heat added, mammon varies, artifact names randomize, deed entry shows purchase count
- [ ] Purchase Tariff Evasion → Worshop Zone prices visibly reduced 25%; make a purchase and confirm +5 heat next morning; skip a day and confirm no heat
- [ ] Kill Sterling → confirm heat is now +25, not +15
- [ ] Stack active deeds, reach heat = 100 → prison endgame fires correctly
- [ ] TypeScript: `tsc --noEmit` clean