### PR TITLE
#273 Fix steal race condition and maxPlayers silent failure

### DIFF
--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -766,22 +766,8 @@
           icon: false,
         },
       );
-    } else if (result === "not_found") {
-      toast(
-        {
-          component: MyToast,
-          props: {
-            title: "Card Not Found",
-            message: `”${match.phrase}” could not be found.`,
-          },
-        },
-        {
-          position: POSITION.BOTTOM_LEFT,
-          toastClassName: "red",
-          timeout: 8000,
-          icon: false,
-        },
-      );
+    } else if (result === “not_found”) {
+      console.error(`performSteal: card “${match.phrase}” (id: ${match.id}) was not found in Firestore — this should not be possible.`);
     }
   };
 

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -552,8 +552,8 @@
   };
 
   const performGuess = async () => {
-    const yourGuess = you.guess.toLowerCase().replace(/”/g, “”);
-    you.guess = “”; // clear before await to prevent double-submit while transaction is in-flight
+    const yourGuess = you.guess.toLowerCase().replace(/”/g, "");
+    you.guess = ""; // clear before await to prevent double-submit while transaction is in-flight
 
     let isThatPhraseYours = false;
     let isAlreadyPlayed = false;
@@ -576,9 +576,9 @@
 
           if (player.playerID === you.playerID) {
             isThatPhraseYours = true;
-          } else if (card.status === “played”) {
+          } else if (card.status === "played") {
             isAlreadyPlayed = true;
-          } else if (card.status === “stolen”) {
+          } else if (card.status === "stolen") {
             isAlreadyStolen = true;
           } else {
             isSuccess = true;
@@ -595,14 +595,14 @@
         {
           component: MyToast,
           props: {
-            title: “Too Late!”,
+            title: "Too Late!",
             // points: match.points,
             message: `”<strong>${match.phrase}</strong>” has already been scored.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: “yellow”,
+          toastClassName: "yellow",
           timeout: 8000,
           icon: false,
         },
@@ -612,13 +612,13 @@
         {
           component: MyToast,
           props: {
-            title: “Too Late!”,
+            title: "Too Late!",
             message: `”${match.phrase ?? yourGuess}” has already been stolen.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: “yellow”,
+          toastClassName: "yellow",
           timeout: 8000,
           icon: false,
         },
@@ -638,7 +638,7 @@
         props: {
           title: "Nope!",
           points: yourLoss,
-          message: `Nobody had “<strong>${you.guess}</strong>”.`,
+          message: `Nobody had “<strong>${yourGuess}</strong>”.`,
         },
       },
       {
@@ -716,52 +716,68 @@
   const rewardGoodGuess = async (match, cardHolder) => {
     const result = await performSteal(db, game.roomCode, match, cardHolder, you);
 
-    if (result === “success”) {
+    if (result === "success") {
       toast(
         {
           component: MyToast,
           props: {
-            title: “Got 'em!”,
+            title: "Got 'em!",
             points: match.points,
             message: `<strong>${cardHolder.name}</strong> had “<strong>${match.phrase}</strong>.”`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: “green”,
+          toastClassName: "green",
           timeout: 8000,
           icon: false,
         },
       );
       logCardTheft(match);
-    } else if (result === “played”) {
+    } else if (result === "played") {
       toast(
         {
           component: MyToast,
           props: {
-            title: “Too Late!”,
+            title: "Too Late!",
             message: `”<strong>${match.phrase}</strong>” has already been scored.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: “yellow”,
+          toastClassName: "yellow",
           timeout: 8000,
           icon: false,
         },
       );
-    } else if (result === “stolen”) {
+    } else if (result === "stolen") {
       toast(
         {
           component: MyToast,
           props: {
-            title: “Too Late!”,
+            title: "Too Late!",
             message: `”${match.phrase}” has already been stolen.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: “yellow”,
+          toastClassName: "yellow",
+          timeout: 8000,
+          icon: false,
+        },
+      );
+    } else if (result === "not_found") {
+      toast(
+        {
+          component: MyToast,
+          props: {
+            title: "Card Not Found",
+            message: `”${match.phrase}” could not be found.`,
+          },
+        },
+        {
+          position: POSITION.BOTTOM_LEFT,
+          toastClassName: "red",
           timeout: 8000,
           icon: false,
         },

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -766,7 +766,7 @@
           icon: false,
         },
       );
-    } else if (result === “not_found”) {
+    } else if (result === "not_found") {
       console.error(`performSteal: card “${match.phrase}” (id: ${match.id}) was not found in Firestore — this should not be possible.`);
     }
   };

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -2,6 +2,7 @@
   import { onMounted, reactive, ref, computed, watchEffect, watch } from "vue";
   import { allCards } from "./ts/_allCards";
   import { eventCards } from "./ts/_eventCards";
+  import { performSteal } from "./ts/_performSteal";
   import { randomNumber, randomFrom, shuffle, preceisePercentOf } from "@/shared/js/_functions.js";
 
   // Toasts
@@ -244,6 +245,10 @@
     if (!amISignedIn.value) {
       const currentPlayersSnap = await getDocs(collection(db, "rooms", game.roomCode, "players"));
       if (currentPlayersSnap.size >= settings.maxPlayers) {
+        toast("This room is full — no more players can join.", {
+          position: POSITION.BOTTOM_CENTER,
+          timeout: 8000,
+        });
         return;
       }
     }
@@ -546,8 +551,9 @@
     logCardScore(card);
   };
 
-  const performGuess = () => {
-    const yourGuess = you.guess.toLowerCase().replace(/"/g, "");
+  const performGuess = async () => {
+    const yourGuess = you.guess.toLowerCase().replace(/”/g, “”);
+    you.guess = “”; // clear before await to prevent double-submit while transaction is in-flight
 
     let isThatPhraseYours = false;
     let isAlreadyPlayed = false;
@@ -570,9 +576,9 @@
 
           if (player.playerID === you.playerID) {
             isThatPhraseYours = true;
-          } else if (card.status === "played") {
+          } else if (card.status === “played”) {
             isAlreadyPlayed = true;
-          } else if (card.status === "stolen") {
+          } else if (card.status === “stolen”) {
             isAlreadyStolen = true;
           } else {
             isSuccess = true;
@@ -583,20 +589,20 @@
     }
 
     if (isSuccess === true) {
-      rewardGoodGuess(match, cardHolder);
+      await rewardGoodGuess(match, cardHolder);
     } else if (isAlreadyPlayed) {
       toast(
         {
           component: MyToast,
           props: {
-            title: "Too Late!",
+            title: “Too Late!”,
             // points: match.points,
-            message: `“<strong>${match.phrase}</strong>” has already been scored.`,
+            message: `”<strong>${match.phrase}</strong>” has already been scored.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: "yellow",
+          toastClassName: “yellow”,
           timeout: 8000,
           icon: false,
         },
@@ -606,23 +612,22 @@
         {
           component: MyToast,
           props: {
-            title: "Too Late!",
-            message: `“${match.phrase ?? yourGuess}” has already been stolen.`,
+            title: “Too Late!”,
+            message: `”${match.phrase ?? yourGuess}” has already been stolen.`,
           },
         },
         {
           position: POSITION.BOTTOM_LEFT,
-          toastClassName: "yellow",
+          toastClassName: “yellow”,
           timeout: 8000,
           icon: false,
         },
       );
     } else if (isThatPhraseYours) {
-      severelyPenalizeTerribleGuess(match, you.guess);
+      severelyPenalizeTerribleGuess(match, yourGuess);
     } else {
-      penalizeBadGuess(you.guess);
+      penalizeBadGuess(yourGuess);
     }
-    you.guess = "";
   };
 
   const penalizeBadGuess = async (yourGuess) => {
@@ -708,37 +713,60 @@
     await addDoc(activitiesRef, newActivity);
   };
 
-  const rewardGoodGuess = (match, cardHolder) => {
-    toast(
-      {
-        component: MyToast,
-        props: {
-          title: "Got 'em!",
-          points: match.points,
-          message: `<strong>${cardHolder.name}</strong> had “<strong>${match.phrase}</strong>.”`,
+  const rewardGoodGuess = async (match, cardHolder) => {
+    const result = await performSteal(db, game.roomCode, match, cardHolder, you);
+
+    if (result === “success”) {
+      toast(
+        {
+          component: MyToast,
+          props: {
+            title: “Got 'em!”,
+            points: match.points,
+            message: `<strong>${cardHolder.name}</strong> had “<strong>${match.phrase}</strong>.”`,
+          },
         },
-      },
-      {
-        position: POSITION.BOTTOM_LEFT,
-        toastClassName: "green",
-        timeout: 8000,
-        icon: false,
-      },
-    );
-
-    //console.log(`rooms/${game.roomCode}/players/${you.playerID}`);
-    const playerRef = doc(db, `rooms/${game.roomCode}/players/${you.playerID}`);
-    updateDoc(playerRef, {
-      score: increment(match.points),
-    });
-
-    const cardRef = doc(db, `rooms/${game.roomCode}/players/${cardHolder.playerID}/hand/${match.id}`);
-    updateDoc(cardRef, {
-      status: "stolen",
-      stolenBy: you.name,
-    });
-
-    logCardTheft(match);
+        {
+          position: POSITION.BOTTOM_LEFT,
+          toastClassName: “green”,
+          timeout: 8000,
+          icon: false,
+        },
+      );
+      logCardTheft(match);
+    } else if (result === “played”) {
+      toast(
+        {
+          component: MyToast,
+          props: {
+            title: “Too Late!”,
+            message: `”<strong>${match.phrase}</strong>” has already been scored.`,
+          },
+        },
+        {
+          position: POSITION.BOTTOM_LEFT,
+          toastClassName: “yellow”,
+          timeout: 8000,
+          icon: false,
+        },
+      );
+    } else if (result === “stolen”) {
+      toast(
+        {
+          component: MyToast,
+          props: {
+            title: “Too Late!”,
+            message: `”${match.phrase}” has already been stolen.`,
+          },
+        },
+        {
+          position: POSITION.BOTTOM_LEFT,
+          toastClassName: “yellow”,
+          timeout: 8000,
+          icon: false,
+        },
+      );
+    }
   };
 
   const createRoom = async () => {

--- a/src/views/meeting/ts/_performSteal.ts
+++ b/src/views/meeting/ts/_performSteal.ts
@@ -1,0 +1,43 @@
+import { doc, increment, runTransaction } from "firebase/firestore";
+import type { Firestore } from "firebase/firestore";
+
+export type StealResult = "success" | "played" | "stolen" | "not_found";
+
+interface StealMatch {
+  id: string;
+  phrase: string;
+  points: number;
+}
+
+interface StealPlayer {
+  playerID: string;
+  name: string;
+}
+
+export async function performSteal(
+  db: Firestore,
+  roomCode: string,
+  match: StealMatch,
+  cardHolder: StealPlayer,
+  you: StealPlayer,
+): Promise<StealResult> {
+  const cardRef = doc(db, `rooms/${roomCode}/players/${cardHolder.playerID}/hand/${match.id}`);
+  const playerRef = doc(db, `rooms/${roomCode}/players/${you.playerID}`);
+
+  try {
+    await runTransaction(db, async (transaction) => {
+      const cardSnap = await transaction.get(cardRef);
+      if (!cardSnap.exists()) throw new Error("not_found");
+      const { status } = cardSnap.data();
+      if (status === "played") throw new Error("played");
+      if (status === "stolen") throw new Error("stolen");
+      transaction.update(cardRef, { status: "stolen", stolenBy: you.name });
+      transaction.update(playerRef, { score: increment(match.points) });
+    });
+    return "success";
+  } catch (err: any) {
+    const msg: string = err?.message ?? "unknown";
+    if (msg === "played" || msg === "stolen" || msg === "not_found") return msg;
+    throw err;
+  }
+}

--- a/tests/court-regressions.spec.ts
+++ b/tests/court-regressions.spec.ts
@@ -131,8 +131,8 @@ describe("Court regressions", () => {
   });
 
   it("uses strict abstention bounds around threshold", () => {
-    const courtVue = fs.readFileSync(path.join(courtRootPath, "Court.vue"), "utf8");
-    expect(courtVue).toContain("return l > -t && l < t;");
+    const courtComputeds = fs.readFileSync(path.join(courtRootPath, "ts/_useCourtComputeds.ts"), "utf8");
+    expect(courtComputeds).toContain("return l > -t && l < t;");
   });
 });
 

--- a/tests/meeting-steal.spec.ts
+++ b/tests/meeting-steal.spec.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+import { performSteal } from "../src/views/meeting/ts/_performSteal";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("firebase/firestore", () => ({
+  doc: vi.fn(() => ({ _isMockRef: true })),
+  increment: vi.fn((n: number) => ({ _increment: n })),
+  runTransaction: vi.fn(),
+}));
+
+import { runTransaction } from "firebase/firestore";
+const mockRunTransaction = runTransaction as Mock;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockDb = {} as any;
+
+const match = { id: "card-1", phrase: "Circle Back", points: 3 };
+const cardHolder = { playerID: "player-2", name: "Karen" };
+const you = { playerID: "player-1", name: "Alex" };
+const roomCode = "ABCDE";
+
+function makeFakeTransaction(cardStatus: string | null) {
+  const update = vi.fn();
+  const get = vi.fn().mockResolvedValue({
+    exists: () => cardStatus !== null,
+    data: () => ({ status: cardStatus }),
+  });
+  return { get, update };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("performSteal", () => {
+  beforeEach(() => {
+    mockRunTransaction.mockReset();
+  });
+
+  it("returns 'success' and writes both docs when card is unplayed", async () => {
+    const tx = makeFakeTransaction("unplayed");
+    mockRunTransaction.mockImplementation(async (_db, fn) => fn(tx));
+
+    const result = await performSteal(mockDb, roomCode, match, cardHolder, you);
+
+    expect(result).toBe("success");
+    expect(tx.update).toHaveBeenCalledTimes(2);
+    expect(tx.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: "stolen", stolenBy: "Alex" }),
+    );
+    expect(tx.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ score: expect.objectContaining({ _increment: 3 }) }),
+    );
+  });
+
+  it("returns 'stolen' and does not increment score when card is already stolen", async () => {
+    const tx = makeFakeTransaction("stolen");
+    mockRunTransaction.mockImplementation(async (_db, fn) => {
+      await fn(tx).catch(() => {}); // transaction callback throws; runTransaction propagates it
+      throw new Error("stolen");
+    });
+
+    const result = await performSteal(mockDb, roomCode, match, cardHolder, you);
+
+    expect(result).toBe("stolen");
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'played' when card has already been scored", async () => {
+    const tx = makeFakeTransaction("played");
+    mockRunTransaction.mockImplementation(async (_db, fn) => {
+      await fn(tx).catch(() => {});
+      throw new Error("played");
+    });
+
+    const result = await performSteal(mockDb, roomCode, match, cardHolder, you);
+
+    expect(result).toBe("played");
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'not_found' when card document does not exist", async () => {
+    const tx = makeFakeTransaction(null); // null → exists() returns false
+    mockRunTransaction.mockImplementation(async (_db, fn) => {
+      await fn(tx).catch(() => {});
+      throw new Error("not_found");
+    });
+
+    const result = await performSteal(mockDb, roomCode, match, cardHolder, you);
+
+    expect(result).toBe("not_found");
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it("simulates race: first caller succeeds, second caller sees 'stolen'", async () => {
+    // tx1: card still unplayed — first caller wins
+    const tx1 = makeFakeTransaction("unplayed");
+    // tx2: card is already stolen by the time the second caller's read resolves
+    const tx2 = makeFakeTransaction("stolen");
+
+    let callCount = 0;
+    mockRunTransaction.mockImplementation(async (_db, fn) => {
+      callCount++;
+      if (callCount === 1) {
+        await fn(tx1);
+      } else {
+        // The callback throws "stolen" before reaching update; runTransaction propagates it
+        await fn(tx2).catch(() => {});
+        throw new Error("stolen");
+      }
+    });
+
+    const [r1, r2] = await Promise.all([
+      performSteal(mockDb, roomCode, match, cardHolder, you),
+      performSteal(mockDb, roomCode, match, cardHolder, { playerID: "player-3", name: "Bob" }),
+    ]);
+
+    expect(r1).toBe("success");
+    expect(r2).toBe("stolen");
+    // Winning transaction wrote exactly one score increment
+    const scoreUpdates = tx1.update.mock.calls.filter(
+      (call) => call[1] && "_increment" in (call[1]?.score ?? {}),
+    );
+    expect(scoreUpdates).toHaveLength(1);
+    // Losing transaction never reached update
+    expect(tx2.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Wraps the steal write in a `runTransaction` so two simultaneous guessers can't both score the same card — the losing transaction reads the already-updated card status and returns `'stolen'` before touching any player doc
- Moves the "Got 'em!" toast to after the transaction confirms, so a player only sees success if the write actually landed
- Clears `you.guess` before the `await` in `performGuess` to prevent double-submit while the transaction is in-flight
- Shows a toast instead of silently returning when `savePlayerInfo` finds the room is full

## New file

`src/views/meeting/ts/_performSteal.ts` — the transactional steal logic extracted to a standalone function so it can be unit tested without mounting the full component.

## Tests

`tests/meeting-steal.spec.ts` — 5 Vitest tests covering the happy path, already-stolen, already-played, card-not-found, and a concurrent race simulation where the first caller wins and the second correctly gets `'stolen'` with no score increment.

Also fixes a pre-existing failure in `tests/court-regressions.spec.ts` where the abstention bounds check was pointing at `Court.vue` after that logic had been extracted to `_useCourtComputeds.ts`.

## Test plan

- [ ] Two browser windows, same room, both guess the same unplayed card simultaneously → exactly one "Got 'em!", the other sees "Too Late!"
- [ ] Only one player's score increments
- [ ] Single-guesser steal still works normally
- [ ] Fill a room to 6, attempt a 7th join → toast appears instead of silent failure
- [ ] `bun run test` option 2 → 97/97 pass

This closes #273