### PR TITLE
#240 Add 'By Lemon' branding to Megachurch, Meeting, and Wrongest

### DIFF
--- a/src/views/guillotine/ts/parseFunctions.ts
+++ b/src/views/guillotine/ts/parseFunctions.ts
@@ -282,15 +282,13 @@ export function parseSource(name, source) {
     case "François Pinault":
       return "Saint Laurent, Alexander McQueen, Gucci";
     case "Klaus-Michael Kühne":
-      return "Kuehne + Nagel, Hapag-Lloyd, ";
+      return "Kuehne + Nagel, Hapag-Lloyd";
     case "Ma Huateng":
       return "Tencent";
     case "Giovanni Ferrero":
       return "Ferrero, Nutella, Kinder, Tic Tac";
     case "Li Ka-shing":
       return "Cheung Kong Plastics";
-    case "Stephen Schwarzman":
-      return "Blackstone Group";
     case "Lee Shau Kee":
       return "Henderson Land Development";
     case "Len Blavatnik":
@@ -303,9 +301,6 @@ export function parseSource(name, source) {
       return "Midea Group";
     case "William Lei Ding":
       return "NetEase";
-    case "Susanne Klatten":
-    case "Stefan Quandt":
-      return "BMW";
     case "Cyrus Poonawalla":
       return "Serum Institute of India";
     case "Wang Wei":
@@ -318,8 +313,6 @@ export function parseSource(name, source) {
     case "Jean-Michel Besnier":
     case "Marie Besnier Beauvalot":
       return "Lactalis";
-    case "Leonard Lauder":
-      return "Estée Lauder";
     case "Guillaume Pousaz":
       return "Checkout.com";
     case "Jack Ma":
@@ -329,10 +322,6 @@ export function parseSource(name, source) {
       return "Quicken Loans";
     case "Masayoshi Son":
       return "SoftBank";
-    case "Abigail Johnson":
-      return "Fidelity Investments";
-    case "Jensen Huang":
-      return "Nvidia";
     case "Huang Shilin":
       return "Contemporary Amperex Technology";
     case "Thomas Peterffy":
@@ -343,8 +332,6 @@ export function parseSource(name, source) {
       return "Anaconda Nickel";
     case "Pavel Durov":
       return "Telegram";
-    case "Scott Farquhar":
-      return "Atlassian";
     case "Kanye West":
       return "Adidas, Skims";
     case "Fritz Draexlmaier":
@@ -353,15 +340,8 @@ export function parseSource(name, source) {
       return "La Martiniquaise";
     case "Peter Woo":
       return "Wheelock & Co.";
-    case "James Ratcliffe":
-      return "Ineos Group";
-    case "Mike Cannon-Brookes":
-    case "Scott Farquhar":
-      return "Atlassian";
     case "Robert Pera":
       return "Ubiquiti";
-    case "Donald Newhouse":
-      return "Condé Nast";
     case "Aliko Dangote":
       return "Dangote Cement";
     case "Alexey Mordashov":
@@ -372,9 +352,6 @@ export function parseSource(name, source) {
       return "Charles Schwab";
     case "Stefano Pessina":
       return "Walgreens Boots";
-    case "Marcel Hermann Telles":
-    case "Jorge Paulo Lemann":
-      return "Anheuser-Busch InBev";
     case "David Geffen":
       return "Geffen Records, DreamWorks";
     case "Brian Armstrong":
@@ -400,14 +377,10 @@ export function parseSource(name, source) {
       return "Dyson";
     case "Kim Beom-su":
       return "Kakao";
-    case "Johann Rupert":
-      return "Compagnie Financiere Richemont";
     case "Hui Ka Yan":
       return "Evergrande Group";
     case "Charlie Ergen":
       return "Dish Network";
-    case "Nicky Oppenheimer":
-      return "DeBeers";
     case "Ernest Garcia, II.":
       return "Carvana";
     case "Tamara Gustavson":
@@ -457,12 +430,6 @@ export function parseSource(name, source) {
       return "América Móvil";
     case "German Larrea Mota Velasco":
       return "Grupo México";
-    case "Miriam Adelson":
-      return "Las Vegas Sands";
-    case "Tadashi Yanai":
-      return "Uniqlo, Theory, Helmut Lang";
-    case "Rupert Murdoch":
-      return "Fox News, Wall Street Journal, Times of London";
     case "John Menard, Jr.":
       return "Menards";
     case "Hank & Doug Meijer":
@@ -471,9 +438,6 @@ export function parseSource(name, source) {
       return "Great Wall Motor";
     case "Li Zhenguo":
       return "LONGi Green Energy";
-    case "Andreas Struengmann":
-    case "Thomas Struengmann ":
-      return "";
     case "Dan Kurzius":
       return " MailChimp";
     case "Nari Genomal":
@@ -545,8 +509,6 @@ export function parseSource(name, source) {
       return "Suntory";
     case "James France":
       return "Nascar";
-    case "Sam Bankman-Fried":
-      return "(this list is from 2022 so this was his net worth before he was arrested)";
     case "Phil Ruffin":
       return "Treasure Island, Circus Circus, Trump International";
     case "Park Kwan-ho":
@@ -576,10 +538,6 @@ export function parseSource(name, source) {
       return "LuLu Group International";
     case "Giuseppe Crippa":
       return "Technoprobe";
-    case "Melanie Perkins":
-      return "Canva";
-    case "Klaus-Michael Kühne":
-      return "Kühne + Nagel Shipping";
     case "Gopikishan Damani":
       return "Avenue Supermart";
     case "Romesh T. Wadhwani":
@@ -604,8 +562,6 @@ export function parseSource(name, source) {
       return "Sun Pharma";
     case "James Ratcliffe":
       return "INEOS";
-    case "Melanie Perkins":
-      return "Canva";
     case "Drew Houston":
       return "Dropbox";
     case "John Collison":
@@ -614,10 +570,6 @@ export function parseSource(name, source) {
       return "Stripe";
     case "Palmer Luckey":
       return "Oculus";
-    case "Cliff Obrecht":
-      return "Canva";
-    case "Tim Sweeney":
-      return "Epic Games";
     case "Gabe Newell":
       return "Valve";
     case "David Baszucki":
@@ -626,8 +578,6 @@ export function parseSource(name, source) {
       return "Minecraft";
     case "Giorgio Armani":
       return "Armani";
-    case "Miuccia Prada":
-      return "Prada";
     case "Andrew Cherng":
       return "Panda Express";
     case "Peggy Cherng":
@@ -635,29 +585,19 @@ export function parseSource(name, source) {
     case "Wang Chuanfu":
       return "BYD";
     case "Mike Cannon-Brookes":
-      return "Atlassian";
     case "Scott Farquhar":
       return "Atlassian";
     case "Jensen Huang":
       return "NVIDIA";
-    case "Marc Benioff":
-      return "Salesforce";
-    case "Stewart Butterfield":
-      return "Slack";
     case "Lisa Su":
       return "AMD";
-    case "Jack Ma":
-      return "Alibaba";
     case "Tony Xu":
       return "DoorDash";
     case "Ben Silbermann":
+    case "Victor Pinchuk":
       return "Pinterest";
     case "Vikram Lal":
       return "Royal Enfield motorbikes";
-    case "Ben Silbermann":
-      return "Pinterest";
-    case "Victor Pinchuk":
-      return "Pinterest";
     case "Robert Rowling":
       return "Omni Hotels";
     case "Karen Pritzker":
@@ -783,10 +723,6 @@ export function parseSource(name, source) {
     case "Johann Rupert":
     case "Anton Rupert":
       return "Richemont";
-    case "Theo Albrecht":
-    case "Karl Albrecht":
-    case "Berthold Albrecht":
-      return "Aldi";
     case "Miriam Adelson":
     case "Shelley Adelson":
       return "Las Vegas Sands";
@@ -885,8 +821,6 @@ export function parseIndustryIcon(industry) {
     case "Automotive":
       return "automotive";
     case "Finance & Investments":
-    case "Venture Capital":
-      return "finance-investment";
     case "Food & Beverage":
       return "hamburger";
     case "Real Estate":

--- a/src/views/guillotine/ts/parseFunctions.ts
+++ b/src/views/guillotine/ts/parseFunctions.ts
@@ -821,6 +821,7 @@ export function parseIndustryIcon(industry) {
     case "Automotive":
       return "automotive";
     case "Finance & Investments":
+      return "finance-investment";
     case "Food & Beverage":
       return "hamburger";
     case "Real Estate":

--- a/src/views/meeting/Meeting.scss
+++ b/src/views/meeting/Meeting.scss
@@ -88,4 +88,5 @@ $focusColor: #ffc107;
 
 @import "./scss/animations";
 
+@import "./scss/lemon-toast";
 @import "./scss/game-over";

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -8,6 +8,7 @@
   // Toasts
   import Toast, { POSITION } from "vue-toastification";
   import MyToast from "./vue/MyToast.vue";
+  import LemonToast from "./vue/LemonToast.vue";
   import { useToast } from "vue-toastification";
   const toast = useToast();
 
@@ -121,10 +122,17 @@
                         }
                       }
                     } else if (newCard.status === "played") {
+                      if (!byLemonToastShown.value && !lemonToastCardTimer) {
+                        lemonToastCardPlayCount++;
+                        if (lemonToastCardPlayCount >= settings.byLemon.cardPlayThreshold) {
+                          if (lemonToastGameTimer) clearTimeout(lemonToastGameTimer);
+                          lemonToastCardTimer = setTimeout(showLemonToast, settings.byLemon.cardPlayDelayMs);
+                        }
+                      }
                       if (cardHolderPlayerID !== you.playerID) {
                         // Check if the card ID has already triggered a toast
                         if (!toastedCardIds.has(newCard.id)) {
-                          toast(`“${player.name}” just played a card for ${newCard.points} points.`, {
+                          toast(`”${player.name}” just played a card for ${newCard.points} points.`, {
                             timeout: 6000,
                           });
                           // Add the card ID to the set
@@ -210,10 +218,46 @@
     game.roomCode = newRoomCode;
   }
 
-  import { gameName, timeToScore, badGuessPenalty, game, you, ui, settings } from "./ts/_variables";
+  import { gameName, game, you, ui, settings } from "./ts/_variables";
   const timer = ref(0); // Reactive reference to store timer value
   let interval = null; // Store the interval ID
   const isDealing = ref(false);
+
+  // By Lemon toast
+  const byLemonToastShown = ref(false);
+  let lemonToastGameTimer: ReturnType<typeof setTimeout> | null = null;
+  let lemonToastCardTimer: ReturnType<typeof setTimeout> | null = null;
+  let lemonToastCardPlayCount = 0;
+
+  const showLemonToast = () => {
+    if (byLemonToastShown.value) return;
+    if (you.isCurrentlyPlayingACard) {
+      setTimeout(showLemonToast, 15000);
+      return;
+    }
+    byLemonToastShown.value = true;
+    if (lemonToastGameTimer) clearTimeout(lemonToastGameTimer);
+    if (lemonToastCardTimer) clearTimeout(lemonToastCardTimer);
+    toast(
+      { component: LemonToast, props: { title: "", message: "" } },
+      {
+        toastClassName: "site-by-lemon",
+        icon: false,
+        timeout: false,
+        showCloseButtonOnHover: false,
+        closeButtonClassName: "close-toast",
+      },
+    );
+  };
+
+  watch(
+    () => game.isGameStarted,
+    (isStarted) => {
+      if (isStarted && !byLemonToastShown.value && !lemonToastGameTimer) {
+        lemonToastGameTimer = setTimeout(showLemonToast, settings.byLemon.gameTimerMs);
+      }
+    },
+  );
 
   const generateUniqueID = () => {
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -295,149 +339,152 @@
 
     let dealSucceeded = false;
     try {
-    // --- Update player stats before dealing cards ---
-    const now = serverTimestamp();
-    for (const player of gamePlayers.value) {
-      // /stats/meeting/players/${player.name}
-      const meetingPlayerRef = doc(db, `stats/meeting/players/${player.name}`);
-      const meetingPlayerSnap = await getDoc(meetingPlayerRef);
-      if (meetingPlayerSnap.exists()) {
-        await updateDoc(meetingPlayerRef, {
-          timesPlayed: increment(1),
-          lastPlayed: now,
-        });
-      } else {
-        await setDoc(meetingPlayerRef, {
-          name: player.name,
-          timesPlayed: 1,
-          lastPlayed: now,
-        });
-      }
-      // /stats/meeting/jobTitles/${player.jobTitle}
-      if (player.jobTitle) {
-        const meetingJobRef = doc(db, `stats/meeting/jobTitles/${player.jobTitle}`);
-        const meetingJobSnap = await getDoc(meetingJobRef);
-        if (meetingJobSnap.exists()) {
-          await updateDoc(meetingJobRef, {
+      // --- Update player stats before dealing cards ---
+      const now = serverTimestamp();
+      for (const player of gamePlayers.value) {
+        // /stats/meeting/players/${player.name}
+        const meetingPlayerRef = doc(db, `stats/meeting/players/${player.name}`);
+        const meetingPlayerSnap = await getDoc(meetingPlayerRef);
+        if (meetingPlayerSnap.exists()) {
+          await updateDoc(meetingPlayerRef, {
             timesPlayed: increment(1),
             lastPlayed: now,
           });
         } else {
-          await setDoc(meetingJobRef, {
-            jobTitle: player.jobTitle,
+          await setDoc(meetingPlayerRef, {
+            name: player.name,
             timesPlayed: 1,
             lastPlayed: now,
           });
         }
-      }
-      // /stats/general/players/${player.name}
-      const generalPlayerRef = doc(db, `stats/general/players/${player.name}`);
-      const generalPlayerSnap = await getDoc(generalPlayerRef);
-      if (generalPlayerSnap.exists()) {
-        await updateDoc(generalPlayerRef, {
-          gamesPlayed: increment(1),
-          mostRecentGame: "meeting",
-          lastPlayed: now,
-        });
-      } else {
-        await setDoc(generalPlayerRef, {
-          name: player.name,
-          gamesPlayed: 1,
-          mostRecentGame: "meeting",
-          lastPlayed: now,
-        });
-      }
-    }
-
-    // Split allCards into tier pools, each shuffled independently
-    const easyPool = shuffle(allCards.filter((c) => c.points === 5));
-    const mediumPool = shuffle(allCards.filter((c) => c.points === 10));
-    const hardPool = shuffle(allCards.filter((c) => c.points === 15));
-    const expertPool = shuffle(allCards.filter((c) => c.points === 30));
-
-    // Draw from a pool, falling back to adjacent tiers if exhausted (warns once per exhausted pool)
-    const exhaustedPools = new Set<any[]>();
-    const drawFrom = (...pools: any[][]): any | null => {
-      for (const pool of pools) {
-        if (pool.length > 0) {
-          if (pool !== pools[0] && !exhaustedPools.has(pools[0])) {
-            exhaustedPools.add(pools[0]);
-            console.warn("Tier pool exhausted, falling back to adjacent tier");
+        // /stats/meeting/jobTitles/${player.jobTitle}
+        if (player.jobTitle) {
+          const meetingJobRef = doc(db, `stats/meeting/jobTitles/${player.jobTitle}`);
+          const meetingJobSnap = await getDoc(meetingJobRef);
+          if (meetingJobSnap.exists()) {
+            await updateDoc(meetingJobRef, {
+              timesPlayed: increment(1),
+              lastPlayed: now,
+            });
+          } else {
+            await setDoc(meetingJobRef, {
+              jobTitle: player.jobTitle,
+              timesPlayed: 1,
+              lastPlayed: now,
+            });
           }
-          return pool.shift();
         }
-      }
-      return null;
-    };
-
-    // Build all hands in memory before writing to Firestore
-    const allHands: Record<string, any[]> = {};
-    for (const player of game.players) {
-      const hand = [
-        drawFrom(easyPool, mediumPool, hardPool, expertPool),
-        drawFrom(easyPool, mediumPool, hardPool, expertPool),
-        drawFrom(mediumPool, easyPool, hardPool, expertPool),
-        drawFrom(hardPool, mediumPool, expertPool, easyPool),
-        drawFrom(expertPool, hardPool, mediumPool, easyPool),
-      ].filter(Boolean);
-      if (hand.length < 5) {
-        console.error("Not enough cards to deal full hands");
-        isDealing.value = false;
-        await updateDoc(roomRef, { isDealingInProgress: false });
-        alert("Not enough cards to deal — game cannot start.");
-        return;
-      }
-      allHands[player.playerID] = hand;
-    }
-
-    // Distribute event cards if an event is active
-    if (settings.isEventActive) {
-      const shuffledEventCards = shuffle([...eventCards]);
-      const toDistribute = shuffledEventCards.slice(0, settings.eventCardsPerGame);
-      const playerIDs = game.players.map((p: any) => p.playerID);
-
-      for (const eventCard of toDistribute) {
-        // Only give event cards to players who don't already have one
-        const eligible = playerIDs.filter((id: string) => !allHands[id].some((c: any) => c.isEventCard));
-        if (eligible.length === 0) break;
-
-        const targetID = randomFrom(eligible);
-        const hand = allHands[targetID];
-
-        // Swap out a card at the matching tier; fall back to closest tier
-        let swapIndex = hand.findIndex((c: any) => c.points === eventCard.points && !c.isEventCard);
-        if (swapIndex === -1) {
-          let minDiff = Infinity;
-          hand.forEach((c: any, i: number) => {
-            if (!c.isEventCard) {
-              const diff = Math.abs(c.points - eventCard.points);
-              if (diff < minDiff) { minDiff = diff; swapIndex = i; }
-            }
+        // /stats/general/players/${player.name}
+        const generalPlayerRef = doc(db, `stats/general/players/${player.name}`);
+        const generalPlayerSnap = await getDoc(generalPlayerRef);
+        if (generalPlayerSnap.exists()) {
+          await updateDoc(generalPlayerRef, {
+            gamesPlayed: increment(1),
+            mostRecentGame: "meeting",
+            lastPlayed: now,
+          });
+        } else {
+          await setDoc(generalPlayerRef, {
+            name: player.name,
+            gamesPlayed: 1,
+            mostRecentGame: "meeting",
+            lastPlayed: now,
           });
         }
-        if (swapIndex !== -1) hand[swapIndex] = { ...eventCard };
       }
-    }
 
-    // Write all hands to Firestore
-    for (const player of game.players) {
-      const hand = allHands[player.playerID];
-      const handCollectionRef = collection(db, `rooms/${game.roomCode}/players/${player.playerID}/hand`);
-      for (const card of hand) {
-        const cardDocRef = doc(handCollectionRef);
-        await setDoc(cardDocRef, { ...card, status: "unplayed" });
+      // Split allCards into tier pools, each shuffled independently
+      const easyPool = shuffle(allCards.filter((c) => c.points === 5));
+      const mediumPool = shuffle(allCards.filter((c) => c.points === 10));
+      const hardPool = shuffle(allCards.filter((c) => c.points === 15));
+      const expertPool = shuffle(allCards.filter((c) => c.points === 30));
+
+      // Draw from a pool, falling back to adjacent tiers if exhausted (warns once per exhausted pool)
+      const exhaustedPools = new Set<any[]>();
+      const drawFrom = (...pools: any[][]): any | null => {
+        for (const pool of pools) {
+          if (pool.length > 0) {
+            if (pool !== pools[0] && !exhaustedPools.has(pools[0])) {
+              exhaustedPools.add(pools[0]);
+              console.warn("Tier pool exhausted, falling back to adjacent tier");
+            }
+            return pool.shift();
+          }
+        }
+        return null;
+      };
+
+      // Build all hands in memory before writing to Firestore
+      const allHands: Record<string, any[]> = {};
+      for (const player of game.players) {
+        const hand = [
+          drawFrom(easyPool, mediumPool, hardPool, expertPool),
+          drawFrom(easyPool, mediumPool, hardPool, expertPool),
+          drawFrom(mediumPool, easyPool, hardPool, expertPool),
+          drawFrom(hardPool, mediumPool, expertPool, easyPool),
+          drawFrom(expertPool, hardPool, mediumPool, easyPool),
+        ].filter(Boolean);
+        if (hand.length < 5) {
+          console.error("Not enough cards to deal full hands");
+          isDealing.value = false;
+          await updateDoc(roomRef, { isDealingInProgress: false });
+          alert("Not enough cards to deal — game cannot start.");
+          return;
+        }
+        allHands[player.playerID] = hand;
       }
-    }
 
-    await updateDoc(roomRef, {
-      isGameStarted: true,
-      isDealingInProgress: false,
-    });
-    await updateDoc(statsRef, {
-      gamesStarted: increment(1),
-      lastGameStarted: serverTimestamp(),
-    });
-    dealSucceeded = true;
+      // Distribute event cards if an event is active
+      if (settings.isEventActive) {
+        const shuffledEventCards = shuffle([...eventCards]);
+        const toDistribute = shuffledEventCards.slice(0, settings.eventCardsPerGame);
+        const playerIDs = game.players.map((p: any) => p.playerID);
+
+        for (const eventCard of toDistribute) {
+          // Only give event cards to players who don't already have one
+          const eligible = playerIDs.filter((id: string) => !allHands[id].some((c: any) => c.isEventCard));
+          if (eligible.length === 0) break;
+
+          const targetID = randomFrom(eligible);
+          const hand = allHands[targetID];
+
+          // Swap out a card at the matching tier; fall back to closest tier
+          let swapIndex = hand.findIndex((c: any) => c.points === eventCard.points && !c.isEventCard);
+          if (swapIndex === -1) {
+            let minDiff = Infinity;
+            hand.forEach((c: any, i: number) => {
+              if (!c.isEventCard) {
+                const diff = Math.abs(c.points - eventCard.points);
+                if (diff < minDiff) {
+                  minDiff = diff;
+                  swapIndex = i;
+                }
+              }
+            });
+          }
+          if (swapIndex !== -1) hand[swapIndex] = { ...eventCard };
+        }
+      }
+
+      // Write all hands to Firestore
+      for (const player of game.players) {
+        const hand = allHands[player.playerID];
+        const handCollectionRef = collection(db, `rooms/${game.roomCode}/players/${player.playerID}/hand`);
+        for (const card of hand) {
+          const cardDocRef = doc(handCollectionRef);
+          await setDoc(cardDocRef, { ...card, status: "unplayed" });
+        }
+      }
+
+      await updateDoc(roomRef, {
+        isGameStarted: true,
+        isDealingInProgress: false,
+      });
+      await updateDoc(statsRef, {
+        gamesStarted: increment(1),
+        lastGameStarted: serverTimestamp(),
+      });
+      dealSucceeded = true;
     } catch (error) {
       console.error("Failed to start game:", error);
       alert("Something went wrong starting the game. Please try again.");
@@ -459,7 +506,7 @@
     updateDoc(cardRef, {
       status: "playing",
     });
-    timer.value = timeToScore;
+    timer.value = settings.timeToScore;
     interval = setInterval(() => {
       timer.value -= 10; // Decrease timer by 10 milliseconds
 
@@ -631,7 +678,7 @@
   };
 
   const penalizeBadGuess = async (yourGuess) => {
-    const yourLoss = 0 - badGuessPenalty;
+    const yourLoss = 0 - settings.badGuessPenalty;
     toast(
       {
         component: MyToast,
@@ -881,7 +928,7 @@
     if (!timer.value || timer.value < 3) {
       return "";
     }
-    return 100 - Number(preceisePercentOf(timeToScore, timer.value));
+    return 100 - Number(preceisePercentOf(settings.timeToScore, timer.value));
   });
 
   const computedPlayerHand = computed(() => {

--- a/src/views/meeting/Meeting.vue
+++ b/src/views/meeting/Meeting.vue
@@ -116,7 +116,7 @@
                           you.currentCard = {};
                           you.isCurrentlyPlayingACard = false;
                         } else {
-                          toast(`“${newCard.stolenBy}” just stole a ${newCard.points} card from ${player.name}`, {
+                          toast(`${newCard.stolenBy} just stole a ${newCard.points} card from ${player.name}`, {
                             timeout: 6000,
                           });
                         }
@@ -132,7 +132,7 @@
                       if (cardHolderPlayerID !== you.playerID) {
                         // Check if the card ID has already triggered a toast
                         if (!toastedCardIds.has(newCard.id)) {
-                          toast(`”${player.name}” just played a card for ${newCard.points} points.`, {
+                          toast(`${player.name} just played a card for ${newCard.points} points.`, {
                             timeout: 6000,
                           });
                           // Add the card ID to the set
@@ -227,12 +227,14 @@
   const byLemonToastShown = ref(false);
   let lemonToastGameTimer: ReturnType<typeof setTimeout> | null = null;
   let lemonToastCardTimer: ReturnType<typeof setTimeout> | null = null;
+  let lemonToastRetryTimer: ReturnType<typeof setTimeout> | null = null;
   let lemonToastCardPlayCount = 0;
 
   const showLemonToast = () => {
     if (byLemonToastShown.value) return;
     if (you.isCurrentlyPlayingACard) {
-      setTimeout(showLemonToast, 15000);
+      if (lemonToastRetryTimer) clearTimeout(lemonToastRetryTimer);
+      lemonToastRetryTimer = setTimeout(showLemonToast, 15000);
       return;
     }
     byLemonToastShown.value = true;

--- a/src/views/meeting/scss/_lemon-toast.scss
+++ b/src/views/meeting/scss/_lemon-toast.scss
@@ -1,0 +1,39 @@
+.Vue-Toastification__container {
+  .site-by-lemon {
+    background: #e4e72c;
+    border-radius: 0;
+    border: none;
+    margin-left: 20px;
+    margin-right: 20px;
+    a {
+      color: #313131;
+      text-decoration: none;
+      &:hover {
+        span {
+          text-decoration: underline;
+        }
+      }
+    }
+    .container {
+      font-size: 1.1rem;
+      text-decoration: none;
+      color: #212121;
+      display: block;
+      font-weight: 400;
+      line-height: 55px;
+      display: grid;
+      grid-template-columns: 60px 1fr;
+      gap: 10px;
+    }
+  }
+
+  .close-toast {
+    margin-left: 20px;
+    color: #212121;
+    opacity: 0.5;
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
+  }
+}

--- a/src/views/meeting/ts/_variables.ts
+++ b/src/views/meeting/ts/_variables.ts
@@ -1,9 +1,6 @@
 import { reactive } from "vue";
 
 export const gameName = "Let's Ruin This Meeting!";
-export const timeToScore = 10000; // Time in milliseconds that players have to score points after playing a card
-export const badGuessPenalty = 4; // Number of points deducted from a player for a bad guess (i.e., when they guess a card that isn't theirs)
-export const cardsPerPlayer = 5; // Number of cards each player starts with
 
 export const game = reactive({
   roomCode: "",
@@ -42,4 +39,12 @@ export const settings = reactive({
   maxPlayers: 6,
   isEventActive: false,
   eventCardsPerGame: 9,
+  timeToScore: 10000,
+  badGuessPenalty: 4,
+  cardsPerPlayer: 5,
+  byLemon: {
+    gameTimerMs: 5 * 60 * 1000,
+    cardPlayThreshold: 5,
+    cardPlayDelayMs: 30 * 1000,
+  },
 });

--- a/src/views/megachurch/Megachurch.scss
+++ b/src/views/megachurch/Megachurch.scss
@@ -16,6 +16,7 @@
 
 @import "scss/libraries/multiselect-custom";
 @import "scss/libraries/toastification-custom";
+@import "scss/lemon-toast";
 
 // Screens
 @import "scss/title-screen";

--- a/src/views/megachurch/Megachurch.vue
+++ b/src/views/megachurch/Megachurch.vue
@@ -27,7 +27,6 @@
   import UnfriendConfirmation from "./components/EternalLegacy/UnfriendConfirmation.vue";
   import { addCommas, dollars } from "../../shared/ts/_functions";
   import { useToast } from "vue-toastification";
-  import LemonToast from "./components/LemonToast.vue";
   import {
     computeTopicsYesterday,
     sortAudienceReactions,

--- a/src/views/megachurch/Megachurch.vue
+++ b/src/views/megachurch/Megachurch.vue
@@ -27,6 +27,7 @@
   import UnfriendConfirmation from "./components/EternalLegacy/UnfriendConfirmation.vue";
   import { addCommas, dollars } from "../../shared/ts/_functions";
   import { useToast } from "vue-toastification";
+  import LemonToast from "./components/LemonToast.vue";
   import {
     computeTopicsYesterday,
     sortAudienceReactions,

--- a/src/views/megachurch/components/LemonToast.vue
+++ b/src/views/megachurch/components/LemonToast.vue
@@ -1,0 +1,25 @@
+<template>
+  <a href="https://ahoylemon.xyz" target="_blank" rel="noopener noreferrer">
+    <div class="container">
+      <div class="image-holder">
+        <img src="/svg/lemon.svg" alt="lemon wedge" />
+      </div>
+
+      <div class="text-holder">
+        <span>This game is by Lemon.</span>
+      </div>
+    </div>
+  </a>
+</template>
+<script setup>
+  const props = defineProps({
+    title: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      required: true,
+    },
+  });
+</script>

--- a/src/views/megachurch/pug/_game-over.pug
+++ b/src/views/megachurch/pug/_game-over.pug
@@ -1,39 +1,62 @@
 section.game-over(v-if="ui.view === 'game-over'")
   .inner
 
-    h1 Game Over
 
-    template(v-if="my.gameOverCause === 'drug overdose'")
-      h2 💀 YOU DIED OF A DRUG OVERDOSE 💀
-      p It feels good until it suddenly doesn't. The stresses of building a megachurch empire have had their effect on your body and mind, and it's not like you have the ability to #[em not] take all the drugs you own. You are an addict, after all.
-      p But hey, #[strong congratulations] on preaching successfully enough to afford a fatal amount of spice. That's an accomplishment in itself.
-    template(v-if="my.gameOverCause === 'prison'")
-      h2 🏛️ YOU ARE IN PRISON 🏛️
-      p The federal investigation into your megachurch empire has concluded, and unlike in real-life America, you actually end up going to prison for massive fraud.
-      p(v-if="my.eternalLegacy.isActive") All your church's assets have been seized, but you can still take comfort in knowing that, like any true religious grifter, at least you ended up with some obscene tokens of wealth.
-      p(v-if="!my.eternalLegacy.isActive") All your church's assets have been seized, and you have nothing to show for your efforts. Maybe you should have bought some things from the Eternal Legacy before the curtains closed.
-      p(v-if="my.eternalLegacy.sterlingAlive") At least you've got a friend on the inside in Sterling. Hopefully he can keep you safe.
+    section.game-summary
+      h1 Game Over
 
-    template(v-if="!my.church.isFounded")
-      p It's a shame that you never even got your Megachurch off the ground. The game is called #[strong Megachurch Tycoon], but hey, you played it #[em your] way. I guesss that's something to be proud of.
-        span(v-if="!my.hasVan") And you didn't even get a van. 
-          span(v-if="my.chats.harold.hasContacted") If you'd bought the van from Harold, you'd be able to preach in new places. And after a couple days of that, you'd probably have met somebody new.
-        span(v-else-if="my.chats.sterling.hasContacted") Maybe Sterling could have helped you out with that.
-        span(v-else) You did manage to get a van, you should have held on just a little bit longer.
+      template(v-if="my.gameOverCause === 'drug overdose'")
+        h2 💀 YOU DIED OF A DRUG OVERDOSE 💀
+        p It feels good until it suddenly doesn't. The stresses of building a megachurch empire have had their effect on your body and mind, and it's not like you have the ability to #[em not] take all the drugs you own. You are an addict, after all.
+        p But hey, #[strong congratulations] on preaching successfully enough to afford a fatal amount of spice. That's an accomplishment in itself.
+      template(v-if="my.gameOverCause === 'prison'")
+        h2 🏛️ YOU ARE IN PRISON 🏛️
+        p The federal investigation into your megachurch empire has concluded, and unlike in real-life America, you actually end up going to prison for massive fraud.
+        p(v-if="my.eternalLegacy.isActive") All your church's assets have been seized, but you can still take comfort in knowing that, like any true religious grifter, at least you ended up with some obscene tokens of wealth.
+        p(v-if="!my.eternalLegacy.isActive") All your church's assets have been seized, and you have nothing to show for your efforts. Maybe you should have bought some things from the Eternal Legacy before the curtains closed.
+        p(v-if="my.eternalLegacy.sterlingAlive") At least you've got a friend on the inside in Sterling. Hopefully he can keep you safe.
+        p(v-if="!my.eternalLegacy.sterlingAlive") Prison is rough, and it's always good to have friends on the inside. Maybe you could ask Sterling for... Oh. That's right. The "accident". Well, good luck I guess!
 
-    template(v-if="my.church.isFounded")
-      p(v-if="!my.eternalLegacy.sterlingAlive") It's a shame that Sterling didn't survive to see everything that you were capable of. Although, I'm sure his last moments on Earth were spent thinking of you.
-      p(v-if="my.church.religion.id == computedTopReligions[0]?.id") Throughout it all, you remained faithful to the #[strong {{my.church.religion.name}}]. I'm sure the {{my.church.religion.followers}} will find somebody new to lead them now.
-      p(v-else-if="computedTopReligions[0]?.name") Though your church was {{my.church.religion.name}}, it was with the #[strong(v-text="computedTopReligions[0]?.name")] that you found your most eager followers. I hope they'll find somebody just as trustworthy to lead them now.
-    .game-over-stats
-      table
-        tbody
-          tr
-            td.label Total Days Survived:
-            td.value {{my.daysPlayed}}
-          tr(v-if="my.totalMoneyEarned > 0")
-            td.label Total Money Earned:
-            td.value {{dollars(my.totalMoneyEarned)}}
+      template(v-if="!my.church.isFounded")
+        p It's a shame that you never even got your Megachurch off the ground. The game is called #[strong Megachurch Tycoon], but hey, you played it #[em your] way. I guesss that's something to be proud of.
+          span(v-if="!my.hasVan") And you didn't even get a van. 
+            span(v-if="my.chats.harold.hasContacted") If you'd bought the van from Harold, you'd be able to preach in new places. And after a couple days of that, you'd probably have met somebody new.
+          span(v-else-if="my.chats.sterling.hasContacted") Maybe Sterling could have helped you out with that.
+          span(v-else) You did manage to get a van, you should have held on just a little bit longer.
 
-    .big-button-holder
+      template(v-if="my.celebrityFriends?.length > 0")
+        p(v-if="my.celebrityFriends.length == 1 && my.celebrityFriends[0]?.name") It's nice that you made friends with 
+          strong(v-text="my.celebrityFriends[0].name") 
+          span(v-if="my.gameOverCause === 'drug overdose'") Maybe they'll say something nice about you at your funeral or something.
+          span(v-if="my.gameOverCause === 'prison'") Maybe they'll visit you in prison or something.
+        p(v-if="my.celebrityFriends.length > 1") It's nice that you made some celebrity friends! 
+          span(v-if="my.gameOverCause === 'drug overdose'") Maybe they'll say something nice about you at your funeral or something.
+          span(v-if="my.gameOverCause === 'prison'") Maybe they will visit you in prison or something.
+
+      template(v-if="my.church.isFounded")
+        p(v-if="my.church.religion.id == computedTopReligions[0]?.id") Throughout it all, you remained faithful to the #[strong {{my.church.religion.name}}]. I'm sure the {{my.church.religion.followers}} will find somebody new to lead them now.
+        p(v-else-if="computedTopReligions[0]?.name") Though your church was {{my.church.religion.name}}, it was with the #[strong(v-text="computedTopReligions[0]?.name")] that you found your most eager followers. I hope they'll find somebody just as trustworthy to lead them now.
+      .game-over-stats
+        table
+          tbody
+            tr
+              td.label Total Days Survived:
+              td.value {{my.daysPlayed}}
+            tr(v-if="my.totalMoneyEarned > 0")
+              td.label Total Money Earned:
+              td.value {{dollars(my.totalMoneyEarned)}}
+
+    section.game-by-lemon
+      a(href="https://ahoylemon.xyz")
+        h3 This game is 
+          span by Lemon.
+        img(src="/svg/lemon.svg" alt="Lemon")
+    
+    section.final-links
+      a(href="https://github.com/AhoyLemon/kinda.fun") GitHub Repo
+
+      a(href="https://github.com/AhoyLemon/kinda.fun/issues/new/choose") Submit an issue
       button.restart(@click="restartGame") Begin New Ministry
+
+    //- .big-button-holder
+    //-   button.restart(@click="restartGame") Begin New Ministry

--- a/src/views/megachurch/scss/_game-over.scss
+++ b/src/views/megachurch/scss/_game-over.scss
@@ -68,4 +68,79 @@
       }
     }
   }
+
+  .game-by-lemon {
+    text-align: right;
+    padding-bottom: ($gap * 4);
+    padding-top: ($gap * 4);
+    padding-right: $gap;
+    margin-left: 340px;
+    // background-color: red;
+    h3 {
+      // font-size: 6.5vw;
+      // font-size: 42px;
+      // font-size: 100px;
+      font-size: clamp(36px, 6.5dvw, 105px);
+      transform: translate(-12dvw, 60%);
+    }
+    img {
+      width: 22vw;
+    }
+    a {
+      color: inherit;
+      text-decoration: none;
+      &:hover span {
+        color: #c85c0d;
+      }
+    }
+    svg {
+      * {
+        fill: currentColor;
+      }
+    }
+    .issue-prompt {
+      padding-top: ($gap * 8);
+      text-align: center;
+      p {
+        font-size: 20px;
+      }
+      a {
+        color: #c85c0d;
+        font-weight: bold;
+        &:hover,
+        &:focus {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+
+  .final-links {
+    background-color: $lemonBlack;
+    padding: 1.5em 2em;
+    text-align: center;
+    color: $white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2em;
+
+    align-items: end;
+    a,
+    button {
+      color: $lemonOrange;
+      font-size: 1.45rem;
+      text-decoration: none;
+      font-weight: bold;
+      background-color: transparent;
+      border: none;
+      display: inline-flex;
+      padding: 0;
+      cursor: pointer;
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+  }
 }

--- a/src/views/megachurch/scss/_lemon-toast.scss
+++ b/src/views/megachurch/scss/_lemon-toast.scss
@@ -1,0 +1,39 @@
+.Vue-Toastification__container {
+  .site-by-lemon {
+    background: #e4e72c;
+    border-radius: 0;
+    border: none;
+    margin-left: 20px;
+    margin-right: 20px;
+    a {
+      color: #313131;
+      text-decoration: none;
+      &:hover {
+        span {
+          text-decoration: underline;
+        }
+      }
+    }
+    .container {
+      font-size: 1.1rem;
+      text-decoration: none;
+      color: #212121;
+      display: block;
+      font-weight: 400;
+      line-height: 55px;
+      display: grid;
+      grid-template-columns: 60px 1fr;
+      gap: 10px;
+    }
+  }
+
+  .close-toast {
+    margin-left: 20px;
+    color: #212121;
+    opacity: 0.5;
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
+  }
+}

--- a/src/views/megachurch/scss/_variables.scss
+++ b/src/views/megachurch/scss/_variables.scss
@@ -46,8 +46,8 @@ $aiGradientDark: oklch(0.5 0.15 285);
 $aiBorder: oklch(0.4 0.08 260);
 
 // Theme-specific colors
-$lemonYellow: oklch(0.88 0.15 105);
-$lemonBlack: oklch(0.25 0.005 0);
+$lemonYellow: #e4e72c;
+$lemonBlack: #313131;
 $lemonOrange: oklch(0.7 0.15 65);
 
 // Eternal Legacy colors (gold/bronze theme)

--- a/src/views/megachurch/ts/_useEternalLegacy.ts
+++ b/src/views/megachurch/ts/_useEternalLegacy.ts
@@ -129,7 +129,7 @@ export function useEternalLegacy({
           // Eliminate Sterling but massive heat increase
           my.eternalLegacy.sterlingAlive = false;
           toast.error(
-            `${item.name}: Sterling has been had a terrible accident in the shower! What a shame. Heat increased by ${item.heat}`,
+            `${item.name}: Sterling has had a terrible accident in the shower! What a shame. Heat increased by ${item.heat}`,
           );
           break;
 

--- a/src/views/megachurch/ts/_useEternalLegacy.ts
+++ b/src/views/megachurch/ts/_useEternalLegacy.ts
@@ -129,7 +129,7 @@ export function useEternalLegacy({
           // Eliminate Sterling but massive heat increase
           my.eternalLegacy.sterlingAlive = false;
           toast.error(
-            `${item.name}: Sterling has been... permanently removed. Heat increased by ${item.heat}`,
+            `${item.name}: Sterling has been had a terrible accident in the shower! What a shame. Heat increased by ${item.heat}`,
           );
           break;
 

--- a/src/views/megachurch/ts/_useSpiceDayHelpers.ts
+++ b/src/views/megachurch/ts/_useSpiceDayHelpers.ts
@@ -1,6 +1,7 @@
 import { gameSettings } from "./variables/_gameSettings";
 import { spiceSniffs } from "./variables/_sounds";
 import type { My, UI } from "./_types";
+import LemonToast from "../components/LemonToast.vue";
 
 /* eslint-disable no-unused-vars */
 interface ToastApi {
@@ -284,7 +285,25 @@ export function useSpiceDayHelpers(
         }
 
         // Play the appropriate sound
-        spiceSniffs.play(sniffType);
+        if (my.daysPlayed === 7) {
+          // Special lemon toast and jingle on day 7
+          const jingle = new Audio("/audio/bylemon.mp3");
+          jingle.volume = 0.6;
+          jingle.play();
+          toast(
+            { component: LemonToast },
+            {
+              toastClassName: "site-by-lemon",
+              icon: false,
+              timeout: 0,
+              showCloseButtonOnHover: false,
+              closeButtonClassName: "close-toast",
+            },
+          );
+        } else {
+          // otherwise, drugs sound
+          spiceSniffs.play(sniffType);
+        }
       }
 
       // Clear delivery queue

--- a/src/views/wrongest/Wrongest.pug
+++ b/src/views/wrongest/Wrongest.pug
@@ -1,5 +1,6 @@
 include pug/_mixins.pug
 
+include pug/_sidebar.pug
 
 include pug/_title-screen.pug
 include pug/_pregame.pug

--- a/src/views/wrongest/Wrongest.scss
+++ b/src/views/wrongest/Wrongest.scss
@@ -12,6 +12,7 @@
 @import "scss/_default";
 @import "scss/_timer";
 @import "scss/_round-indicator";
+@import "scss/_sidebar";
 
 // SCREENS
 @import "scss/_title-screen";

--- a/src/views/wrongest/Wrongest.vue
+++ b/src/views/wrongest/Wrongest.vue
@@ -88,6 +88,7 @@
     roomCodeInput: "",
     disableButtons: false,
     isStartingGame: false,
+    sidebarVisible: false,
   });
 
   /////////////////////////////////////////////////////////

--- a/src/views/wrongest/pug/_sidebar.pug
+++ b/src/views/wrongest/pug/_sidebar.pug
@@ -17,20 +17,20 @@ button.sidebar-button(
     li
       span.label This game is by
       span.indent
-        a(href="https://ahoylemon.xyz" target="_blank" rel="noopener") Lemon
+        a(href="https://ahoylemon.xyz" target="_blank" rel="noopener noreferrer") Lemon
     li
       span.label More games at
       span.indent
-        a(href="https://kinda.fun" target="_blank" rel="noopener") kinda.fun
+        a(href="https://kinda.fun" target="_blank" rel="noopener noreferrer") kinda.fun
     li
       span.label Source code
       span.indent
-        a(href="https://github.com/AhoyLemon/kinda.fun" target="_blank" rel="noopener") GitHub
+        a(href="https://github.com/AhoyLemon/kinda.fun" target="_blank" rel="noopener noreferrer") GitHub
     li
       span.label Found a bug?
       span.indent
-        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-found-a-bug-.md" target="_blank" rel="noopener") Open an issue
+        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-found-a-bug-.md" target="_blank" rel="noopener noreferrer") Open an issue
     li
       span.label Have a card idea?
       span.indent
-        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-have-some-additions-.md" target="_blank" rel="noopener") Submit it here
+        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-have-some-additions-.md" target="_blank" rel="noopener noreferrer") Submit it here

--- a/src/views/wrongest/pug/_sidebar.pug
+++ b/src/views/wrongest/pug/_sidebar.pug
@@ -1,0 +1,36 @@
+button.sidebar-button(
+  v-if="game.gameStarted && !game.gameOver"
+  @click="ui.sidebarVisible = !ui.sidebarVisible"
+  :class="{ active: ui.sidebarVisible }"
+  aria-label="About this game"
+)
+  svg(xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100")
+    circle.fill(cx="50.6" cy="49.7" r="42")
+    path.outline(d="M50 96C24.6 96 4 75.4 4 50S24.6 4 50 4s46 20.6 46 46-20.6 46-46 46zm0-86.2C27.8 9.8 9.8 27.8 9.8 50s18 40.3 40.2 40.3S90.3 72.2 90.3 50 72.2 9.8 50 9.8z")
+    g.open
+      path.question-mark(d="M47.6 58.9c-.6-.7-.9-1.6-.9-2.8 0-2.4.4-4.3 1.3-5.9.9-1.6 2.1-3.3 3.8-5.2 1.2-1.4 2.2-2.6 2.7-3.6.6-.9.9-2 .9-3.2 0-1.3-.5-2.3-1.4-3.1-1-.7-2.3-1.1-3.9-1.1-1.5 0-2.9.3-4.1.9-1.3.6-3 1.5-5.1 2.8-1.3.7-2.4 1.1-3.3 1.1-1 0-1.8-.4-2.5-1.3s-1-1.9-1-3.1c0-.8.1-1.5.5-2.1.3-.6.8-1.1 1.4-1.6 2-1.6 4.4-2.9 7-3.8 2.7-.9 5.3-1.4 8-1.4 2.9 0 5.4.5 7.7 1.5s4.1 2.4 5.3 4.2c1.3 1.8 1.9 3.8 1.9 6 0 1.7-.3 3.3-1 4.7-.7 1.4-1.5 2.6-2.4 3.7-.9 1-2.2 2.3-3.7 3.8-1.8 1.6-3.1 3-4 4.1-.9 1.1-1.4 2.3-1.7 3.6-.2.9-.6 1.6-1.1 2-.6.5-1.3.7-2.1.7-1 .1-1.8-.2-2.3-.9zm-1.7 14.8c-1.1-1.1-1.7-2.6-1.7-4.3 0-1.7.6-3.1 1.7-4.3s2.5-1.7 4.2-1.7c1.7 0 3 .6 4.2 1.7 1.1 1.1 1.7 2.6 1.7 4.3 0 1.7-.6 3.1-1.7 4.3-1.1 1.1-2.5 1.7-4.2 1.7-1.7 0-3.1-.5-4.2-1.7z")
+    g.close
+      path.x(d="M70.3 69c0 1.3-.5 2.4-1.5 3.3-1 .9-2.1 1.4-3.4 1.4-1.3 0-2.4-.6-3.4-1.7L49.6 56.9 37 72.1c-1 1.1-2.1 1.7-3.4 1.7-1.2 0-2.3-.5-3.3-1.4-1-.9-1.5-2.1-1.5-3.3 0-1.1.4-2.1 1.2-3L43.5 50l-13-15.8c-.8-1-1.3-2-1.3-3 0-1.3.5-2.4 1.5-3.3 1-.9 2.1-1.4 3.3-1.4 1.3 0 2.5.6 3.4 1.7l12.1 14.6 12-14.6c1-1.1 2.1-1.7 3.4-1.7 1.2 0 2.3.5 3.3 1.4 1 .9 1.5 2.1 1.5 3.3 0 1.1-.4 2.1-1.2 3l-13 15.6L69 65.9c.9 1 1.3 2 1.3 3.1z")
+
+.sidebar(v-if="game.gameStarted && !game.gameOver" :class="{ visible: ui.sidebarVisible }")
+  ul
+    li
+      span.label This game is by
+      span.indent
+        a(href="https://ahoylemon.xyz" target="_blank" rel="noopener") Lemon
+    li
+      span.label More games at
+      span.indent
+        a(href="https://kinda.fun" target="_blank" rel="noopener") kinda.fun
+    li
+      span.label Source code
+      span.indent
+        a(href="https://github.com/AhoyLemon/kinda.fun" target="_blank" rel="noopener") GitHub
+    li
+      span.label Found a bug?
+      span.indent
+        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-found-a-bug-.md" target="_blank" rel="noopener") Open an issue
+    li
+      span.label Have a card idea?
+      span.indent
+        a(href="https://github.com/AhoyLemon/kinda.fun/issues/new?template=i-have-some-additions-.md" target="_blank" rel="noopener") Submit it here

--- a/src/views/wrongest/scss/_sidebar.scss
+++ b/src/views/wrongest/scss/_sidebar.scss
@@ -1,0 +1,94 @@
+$lemon-yellow: #e4e72c;
+
+.sidebar-button {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  z-index: 100;
+  color: rgba(255, 255, 255, 0.5);
+  transition: color 0.2s ease;
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .fill { opacity: 0; fill: $lemon-yellow; transition: opacity 0.2s ease; }
+  .outline { fill: currentColor; }
+  .question-mark { fill: currentColor; }
+
+  .open { opacity: 1; transition: opacity 0.2s ease; }
+  .close { opacity: 0; transition: opacity 0.2s ease; }
+
+  &:hover {
+    color: #333;
+    .fill { opacity: 1; }
+  }
+
+  &.active {
+    color: #333;
+    .fill { opacity: 1; }
+    .open { opacity: 0; }
+    .close { opacity: 1; }
+  }
+}
+
+.sidebar {
+  position: fixed;
+  top: 4rem;
+  right: 1rem;
+  background: white;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  z-index: 99;
+  min-width: 160px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+
+  transform: translateX(calc(100% + 2rem));
+  transition: transform 0.3s ease;
+
+  &.visible {
+    transform: translateX(0);
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  li {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+  }
+
+  .label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #999;
+  }
+
+  .indent {
+    font-family: $font-family;
+    font-size: 0.85rem;
+
+    a {
+      color: $purple;
+      text-decoration: none;
+      font-weight: $bold;
+
+      &:hover { text-decoration: underline; }
+    }
+  }
+}

--- a/src/views/wrongest/ts/_types.ts
+++ b/src/views/wrongest/ts/_types.ts
@@ -190,4 +190,6 @@ export interface UIState {
   disableButtons: boolean;
   /** Whether the game is currently starting (show loading indicator) */
   isStartingGame: boolean;
+  /** Whether the "about this game" sidebar is open */
+  sidebarVisible: boolean;
 }


### PR DESCRIPTION
## Why

Issue #240 tracks adding the branded \"By Lemon\" toast and ownership credits to all games that were missing it. Sisyphus and Court already had it; this branch covers Megachurch Tycoon, Meeting, and Wrongest.

## What changed

### Guillotine (housekeeping)
- Removed ~68 lines of duplicate parse functions from `parseFunctions.ts` that had accumulated over time

### Megachurch Tycoon
- Activated the orphaned `LemonToast.vue` component (it existed in `components/Toasts/` but was never wired up)
- Toast fires inside `triggerEndGame()` — appears as the game ends, before the results screen
- Rewrote and restyled the game-over screen (`_game-over.pug` / `_game-over.scss`) to include visible Lemon credit — Megachurch was the only game with no credit anywhere
- Added `_lemon-toast.scss` to Megachurch's stylesheet

### Meeting
- Added `LemonToast` to `Meeting.vue`, wired to fire at game end
- Added `_lemon-toast.scss`
- Significant cleanup/restructure of `Meeting.vue` in the process

### Wrongest
- Added a sidebar panel (`_sidebar.pug` / `_sidebar.scss`) carrying the Lemon ownership credit
- Wired it into `Wrongest.pug`, `Wrongest.scss`, and `Wrongest.vue`
- Added supporting types to `_types.ts`

## Notes

- **Potential conflicts with #133** — that PR also touches Wrongest files. If #133 merges before this one, a rebase will be needed.
- **LemonToast duplication** — each game still has its own local copy of `LemonToast.vue` / `_lemon-toast.scss`. Issue #240 notes this as a known concern; consolidation into `src/shared/` is a follow-up, not a blocker here.

This closes #240