### PR TITLE
#279 Fix monthly-deps branch sync failing with 422 on first run

### DIFF
--- a/.github/workflows/monthly-deps-update.yml
+++ b/.github/workflows/monthly-deps-update.yml
@@ -364,13 +364,19 @@ jobs:
           })
 
           try:
+              api('GET', f'repos/{repo}/git/ref/heads/{branch}')
+              branch_exists = True
+          except urllib.error.HTTPError as error:
+              if error.code != 404:
+                  raise
+              branch_exists = False
+
+          if branch_exists:
               api('PATCH', f'repos/{repo}/git/refs/heads/{branch}', {
                   'sha': commit['sha'],
                   'force': True,
               })
-          except urllib.error.HTTPError as error:
-              if error.code != 404:
-                  raise
+          else:
               api('POST', f'repos/{repo}/git/refs', {
                   'ref': f'refs/heads/{branch}',
                   'sha': commit['sha'],


### PR DESCRIPTION
## Why

The monthly dependency update workflow was failing at the "Sync dependency branch via GitHub API" step with `HTTP Error 422: Unprocessable Entity`.

The script tried to PATCH the branch ref, and if that returned 404 it would fall through to a POST (create). But GitHub's API returns **422** — not 404 — when you PATCH a non-existent ref (`"Reference does not exist"`). Since the exception handler only caught 404, the 422 was re-raised and the step failed every time the branch didn't exist yet (first run of each month).

## What changed

Replaced the PATCH-then-catch-404 pattern with a GET-first check: explicitly test whether the branch exists, then PATCH or POST based on that result. This avoids depending on PATCH's ambiguous error code.

This closes #279