### PR TITLE
Court: Go To The Lectern Without Notes (#282)

### DIFF
--- a/docs/court.md
+++ b/docs/court.md
@@ -1,63 +1,148 @@
 # Supreme Court: The Card Game
 
-This is a game about convincing nine justices to agree with you, using logic, emotional manipulation, flattery, bribery, and occasional chaos.
+Convince nine justices to agree with you using logic, emotional manipulation, flattery, bribery, and occasional chaos. So, basically the real Supreme Court. Except for the part where they actually change their minds.
 
-So, basically the real Supreme Court.
+You are a lawyer arguing a case. Each justice has a **leaning** from −100 (Strongly Against you) to +100 (Strongly For you). When the trial ends, you want more **For** votes than **Against**.
 
-## What You Are Trying To Do
+---
 
-Get more **For** votes than **Against** votes.
+## The Numbers That Matter
 
-That is the whole game.
+| Thing                    | Value                              |
+| ------------------------ | ---------------------------------- |
+| Justices on the bench    | **9** (can change in Campaign)     |
+| Rounds per trial         | **5**                              |
+| Cards you play per round | **1** (opponent also plays 1)      |
+| Playbook size            | **5** shared cards                 |
+| Leaning range            | **−100 → +100**                    |
+| Single-target card power | base × **8**                       |
+| All-bench card power     | base × **4** per justice           |
+| Your tactics hit         | **20% harder** than the opponent's |
 
-You can do that by:
+**Vote thresholds** (where a justice's leaning lands them):
 
-- taking principled positions and trying to improve society
-- chasing easy wins by defending awful outcomes
-- doing both, depending on how bad you need this round
+| Leaning Range | Vote Category               |
+| ------------- | --------------------------- |
+| +60 or higher | Strongly For                |
+| +10 to +59    | Leaning For                 |
+| −9 to +9      | **Undecided** (may abstain) |
+| −10 to −59    | Leaning Against             |
+| −60 or lower  | Strongly Against            |
 
-No judgment. Okay, some judgment.
+A justice within **±10** is essentially undecided and can abstain. In a tight trial, **dragging an enemy to neutral is as good as winning their vote** — they stop counting against you.
 
-## The Only Numbers You Really Need
+---
 
-- **9 justices** on the bench (though that can change if you play your cards right)
-- **5 rounds** per trial
-  - **1 card** played by you each round
-  - **1 card** played by the opponent each round
+## How a Trial Works
 
-If a justice is close to neutral, they may abstain. Abstentions can swing close games.
-
-## How A Trial Works
-
-1. You play a tactic card.
-2. Opponent plays a tactic card.
+1. You play one tactic from the shared Playbook.
+2. The opponent plays one.
 3. Leanings shift.
-4. Repeat until round 5, then vote.
+4. Repeat for **5 rounds**, then everyone votes.
 
-Highest **For** count wins.
+Most For votes wins. Ties are possible and they count as ties — don't leave a justice sitting at exactly neutral if you can help it.
 
-## The Playbook
+---
 
-You and your opponent pull from the same Playbook.
+## Reading a Justice
 
-If you use a good card now, they cannot use that exact card this turn.
+Tap any justice to see their **stats** and **weaknesses** (each 1–10). Tactics scale off these, so the bench overview bar (best stat, worst stat, biggest exploit) is your targeting cheat sheet.
 
-Sometimes the best play is not "most powerful card."
-Sometimes it is "I refuse to let you have this."
+**Stats**
 
-## Three Useful Habits
+- **Logic** — receptive to citations and reasoned argument.
+- **Charisma** — resists crowd-pleasing stunts; high-charisma justices also _spread_ their swing to allies (see Knock-on).
+- **Empathy** — moved by emotional appeals.
+- **Susceptibility** — how easily they believe / get rattled. High susceptibility = a mark.
+- **Party Loyalty** — how partisan they vote, and how hard partisan plays land.
 
-1. **Flip one justice at a time.**
-   Big spreads are nice, but flipping a single vote is often the match.
+**Weaknesses** — `flattery`, `bribery`, `blackmail`, `threats`. A weakness-based attack scales **× (weakness ÷ 5)**: a justice with bribery **10** takes _double_ a justice with bribery **5**, while a justice at **2** barely budges (and may resent the attempt).
 
-2. **Protect your lead.**
-   If you are ahead late, play defense and denial instead of meme plays.
+**Logic vs. Empathy is a spectrum.** "Head" tactics (Cite Precedents) reward justices whose logic beats their empathy; "heart" tactics (Emotional Appeal) reward the reverse. Aiming a heart tactic at a head justice is mostly wasted.
 
-3. **Use chaos when behind.**
-   Wildcard cards are comeback tools, not victory laps.
+---
 
-## Quick Starter Plan
+## The Playbook (and Denial)
 
-- **Rounds 1-2:** identify who is flippable
-- **Rounds 3-4:** lock in your best allies
-- **Round 5:** play for vote count, not style points
+You and your opponent draw from the **same** five face-up cards. Playing a card removes it for the turn, so a card you take is a card they can't.
+
+> Sometimes the strongest play isn't "biggest swing." It's "I refuse to let you have that." If the opponent is one Cite Precedents away from a comeback, take it — or claim it with **I Call Dibs**.
+
+---
+
+## The Chief Justice
+
+The Chief (⚖ badge) is the most valuable single target:
+
+- **Harder to sway** — incoming swings are roughly **halved** in both directions.
+- **Influential** — sway the Chief with a single-target card and same-party justices follow at **~50%** of that swing.
+
+Flipping the Chief is slow but contagious. **Elevate to Chief** can also move the crown onto someone you want amplified (and it strips their resistance).
+
+---
+
+## Knock-on Effects
+
+- **Chief knock-on:** single-target sway on the Chief ripples to same-party justices at ~50%.
+- **Charisma knock-on:** sway a high-charisma justice (7+) and they may pull a same-party peer along (**7 → 25%**, **8 → 50%**, **9 → 75%**, **10 → 100%** chance, at ~30% of the swing).
+
+Translation: a charismatic, same-party cluster is a force multiplier. Hit the influencer, not the loner.
+
+---
+
+## Tactics Worth Knowing
+
+**Bread and butter**
+
+- **Cite Precedents / Emotional Appeal** — broad sways that reward logical / empathetic benches respectively.
+- **Bribe / Leak to the Press / Threaten / Shameless Flattery** — single-target weakness exploits. Check the 🎯 Exploit chip first.
+
+**Tempo & timing**
+
+- **Whisper Campaign** — a small shift toward you _every remaining round_. Worth the most on **Round 1** (it fires all 5 rounds), nearly worthless on Round 5.
+- **Encourage a Nap** — a justice skips the next round and wakes **+15** friendlier. Great for parking a swing vote you already own.
+- **Mess With The Calendar** — both sides skip a round. A closing move when you're **ahead** and want fewer swings to happen.
+
+**Control & swing**
+
+- **Recuse Yourself!** — resets a target to neutral and makes them sticky. Best used on an enemy who's Strongly Against.
+- **Swap Clerks** — exchange two justices' leanings. Turn your worst enemy and best friend into… the opposite.
+- **Reframe The Debate** — pick a topic; every justice with a known stance on it lurches **±45**. Swingy, read the bench first.
+- **Betray Your Friend** — sacrifice a Strongly-For justice (they flip hard against) to rally opposing-party enemies toward you. A comeback gamble, not a lead-protector.
+
+**Chaos / wildcards**
+
+- **Go To The Lectern Without Notes** — flips the whole Playbook face-down, redraws, reshuffles, and you commit to a card **blind**. Whatever you play resolves at **1.6× power**. High risk, high reward — you can't see what you're playing until it lands, and you can't back out.
+- **I Call Dibs** — claim 2 cards for your exclusive use (denial + stash).
+- **Purge the Record** — burn all 5 Playbook cards and draw fresh. Use when the board is bad for you and good for them.
+
+---
+
+## A Round-by-Round Plan
+
+- **Rounds 1–2 — Map the bench.** Identify the flippable middle (Undecided/Leaning) and start long-game plays like Whisper Campaign. Don't waste big swings on justices who are already locked.
+- **Rounds 3–4 — Commit.** Lock in your best allies, exploit the biggest weakness on the bench, and work the Chief if it's contagious.
+- **Round 5 — Count, don't style.** Play for raw vote count. Nudging two enemies to neutral often beats one flashy flip. Protect a lead with denial (Dibs) or a round-skip (Calendar).
+
+**Three habits that win games**
+
+1. **Flip one vote at a time** when it's the deciding one — a single clean flip beats a wide, shallow spread.
+2. **Protect your lead late.** When ahead, deny and stall instead of swinging for highlights.
+3. **Save chaos for when you're behind.** Lectern Without Notes, Betray, and Reframe are comeback tools, not victory laps.
+
+---
+
+## Campaign Mode
+
+Quick Play is a single trial. **Campaign** strings **5 cases** together with persistent consequences:
+
+- **Objectives** — a win condition for the whole run (e.g. win them all, force 5–4 splits). Chosen at the start.
+- **Recess** between cases — collect **reward cards**, and justices may **retire or die** (≈50% chance per recess, **1–3** at a time), opening seats you nominate to fill.
+- **Elections** — the sitting president can lose (≈50% in a contested election, capped at **2 terms**), changing who future nominees favor.
+- **Campaign-only tactics** — e.g. **Suggest Retirement** (tank a justice now, guarantee their seat opens at recess).
+
+Campaigns reward thinking past the current trial: a justice you can't win today might retire tomorrow.
+
+---
+
+_For engine internals (effect resolution, stat scaling, the composables behind `Court.vue`), see the [Developer Guide](DEVELOPER_GUIDE.md)._

--- a/scripts/npm-run/test.js
+++ b/scripts/npm-run/test.js
@@ -41,6 +41,7 @@ const options = [
       "tests/court-stats-helpers.spec.ts",
       "tests/court-tactic-effects.spec.ts",
       "tests/court-toast-feedback.spec.ts",
+      "tests/court-unique-ids.spec.ts",
     ],
   },
 ];

--- a/src/views/court/Court.vue
+++ b/src/views/court/Court.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-  import { reactive, onMounted } from "vue";
-  import { useFirestore } from "vuefire";
+  import { reactive, computed, onMounted } from "vue";
   import { useToast, POSITION } from "vue-toastification";
   import TacticToast from "./components/TacticToast.vue";
   import LemonToast from "./components/LemonToast.vue";
@@ -21,25 +20,16 @@
   import { rewardCards } from "./ts/_rewards";
   import { useCampaignManager } from "./ts/_campaignManager";
   import { playJusticeVoice, playKavanaughBeer } from "./ts/_sounds";
-  import {
-    classifyJusticeVote,
-    computeTacticShiftMetrics,
-    createCourtStatsHelpers,
-    getAttackedJusticeNamesForPlay,
-    getOutcomeFromVerdict,
-    getTrackedStanceNamesForOutcome,
-    getWinningSide,
-    type CourtOutcome,
-  } from "./ts/_statsHelpers";
+  import { getAttackedJusticeNamesForPlay } from "./ts/_statsHelpers";
   import { useCourtComputeds } from "./ts/_useCourtComputeds";
   import { useCourtHelpers, getKeyStats, justiceTypeLabel, sideStanceTags, targetLabel, voteLabel, justiceImageUrl, presidentImageUrl, justiceHints } from "./ts/_useCourtHelpers";
   import { useCourtTurns } from "./ts/_useCourtTurns";
+  import { useCourtLectern, type InitiateResult } from "./ts/_useCourtLectern";
+  import { useCourtStats } from "./ts/_useCourtStats";
 
   // ── Game settings ──────────────────────────────────────────
 
   const toast = useToast();
-  const db = useFirestore();
-  const courtStats = createCourtStatsHelpers(db);
   const trialAttackedJustices = new Set<string>();
   let campaignEndLogged = false;
   let byLemonJinglePlayed = false;
@@ -118,6 +108,9 @@
     reframeStanceChoices: [] as StanceType[],
     reframeStanceTacticId: null as number | null,
     reframeStanceSelection: null as StanceType | null,
+    lecternMode: false,
+    lecternBoostPending: false,
+    lecternBlindTacticId: null as number | null,
   });
 
   const campaign = reactive<{ data: CampaignState | null }>({ data: null });
@@ -130,6 +123,7 @@
       targetName: string;
       results: { justiceName: string; change: number }[];
       round: number;
+      viaLectern?: boolean; // played blind via "Go To The Lectern Without Notes"
     }>,
   });
 
@@ -139,125 +133,6 @@
       votes: Record<number, boolean>;
     }>
   >([]);
-
-  // ─── Firestore Stats ───────────────────────────────────────
-
-  function getCurrentOutcome(): CourtOutcome | null {
-    if (!verdict.value) return null;
-    return getOutcomeFromVerdict(verdict.value);
-  }
-
-  async function trackQuickplayStarted(): Promise<void> {
-    await courtStats.writeCourtAggregateStats({
-      gamesStarted: 1,
-      quickplaysStarted: 1,
-      lastQuickplayStarted: "__SERVER_TIMESTAMP__",
-      lastGameStarted: "__SERVER_TIMESTAMP__",
-    });
-  }
-
-  async function trackTacticPlay(tactic: Tactic, actor: TurnActor, results: Array<{ change: number }>): Promise<void> {
-    const metrics = computeTacticShiftMetrics(results);
-    await courtStats.writeTacticStats({
-      tacticName: tactic.name,
-      actor,
-      metrics: { ...metrics, netShift: Math.abs(metrics.netShift) },
-    });
-  }
-
-  function buildVoteBuckets(): Record<string, "prosecution" | "defense" | "abstain"> {
-    if (!game.playerSide) return {};
-    const playerSide = game.playerSide;
-
-    return Object.fromEntries(
-      game.bench.map((justice) => {
-        const leaning = game.leanings[justice.id] ?? 0;
-        return [justice.name, classifyJusticeVote(leaning, playerSide)];
-      }),
-    );
-  }
-
-  async function trackTrialVerdictStats(options: { isQuickplay: boolean }): Promise<void> {
-    if (!game.currentCase || !game.playerSide) return;
-
-    const outcome = getCurrentOutcome();
-    if (!outcome) return;
-
-    const winningSide = getWinningSide(game.playerSide, outcome);
-    const aggregateOutcomeField = outcome === "won" ? "Won" : outcome === "lost" ? "Lost" : "Tied";
-    const benchJusticeNames = game.bench.map((justice) => justice.name);
-    const stanceNames = getTrackedStanceNamesForOutcome(game.currentCase, game.playerSide, outcome);
-    const voteByJusticeName = buildVoteBuckets();
-
-    const aggregateUpdates: Record<string, string | number> = {
-      totalCasesWon: outcome === "won" ? 1 : 0,
-      totalCasesLost: outcome === "lost" ? 1 : 0,
-      totalCasesTied: outcome === "tied" ? 1 : 0,
-    };
-
-    if (options.isQuickplay) {
-      aggregateUpdates.gamesFinished = 1;
-      aggregateUpdates.quickplaysFinished = 1;
-      aggregateUpdates[`quickplays${aggregateOutcomeField}`] = 1;
-      aggregateUpdates.lastQuickplayFinished = "__SERVER_TIMESTAMP__";
-      aggregateUpdates.lastGameFinished = "__SERVER_TIMESTAMP__";
-    }
-
-    await Promise.all([
-      courtStats.writeCourtAggregateStats(aggregateUpdates),
-      courtStats.writeCaseStats({
-        caseName: game.currentCase.name,
-        outcome,
-        winningSide,
-      }),
-      courtStats.writeJusticeStats({
-        benchJusticeNames,
-        attackedJusticeNames: [...trialAttackedJustices],
-      }),
-      courtStats.writeStanceStats({
-        stanceNames,
-        outcome,
-      }),
-      courtStats.writeCaseJusticeVoteStats({
-        caseName: game.currentCase.name,
-        voteByJusticeName,
-        prosecutionName: game.currentCase.prosecution.name,
-        defenseName: game.currentCase.defendant.name,
-      }),
-    ]);
-  }
-
-  async function trackCampaignStarted(campaignName: string): Promise<void> {
-    await Promise.all([
-      courtStats.writeCourtAggregateStats({
-        gamesStarted: 1,
-        campaignsStarted: 1,
-        lastCampaignStarted: "__SERVER_TIMESTAMP__",
-        lastGameStarted: "__SERVER_TIMESTAMP__",
-      }),
-      courtStats.writeCampaignStats({
-        campaignName,
-        event: "start",
-      }),
-    ]);
-  }
-
-  async function trackCampaignCompleted(campaignName: string, won: boolean): Promise<void> {
-    await Promise.all([
-      courtStats.writeCourtAggregateStats({
-        gamesFinished: 1,
-        campaignsFinished: 1,
-        campaignsWon: won ? 1 : 0,
-        campaignsLost: won ? 0 : 1,
-        lastCampaignFinished: "__SERVER_TIMESTAMP__",
-        lastGameFinished: "__SERVER_TIMESTAMP__",
-      }),
-      courtStats.writeCampaignStats({
-        campaignName,
-        event: won ? "win" : "loss",
-      }),
-    ]);
-  }
 
   // ─── Helpers ─────────────────────────────────────────────────
 
@@ -385,22 +260,8 @@
     );
   }
 
-  // ─── Turn Management (composable) ────────────────────────────
-  // applyTactic is a function declaration and is hoisted, so the closure below resolves correctly.
-
-  const { endPlayerTurn, endOpponentTurn, getEligibleMultiTargetJustices } = useCourtTurns(
-    game,
-    campaign,
-    ui,
-    {
-      trackTrialVerdictStats,
-      applyTactic: (t, j, a) => applyTactic(t, j, a),
-      shuffle,
-      triggerLemonMomentIfDue,
-    },
-  );
-
   // ─── Computed Values (composable) ────────────────────────────
+  // Created first so `verdict` is available to the stats composable below.
 
   const {
     allJustices,
@@ -426,9 +287,70 @@
     previewPresetChief,
   } = useCourtComputeds({ game, ui, courtReport });
 
+  // ─── Firestore Stats (composable) ────────────────────────────
+
+  const stats = useCourtStats({ game, verdict, trialAttackedJustices });
+
+  // ─── Turn Management (composable) ────────────────────────────
+  // applyTactic is a function declaration and is hoisted, so the closure below resolves correctly.
+
+  const { endPlayerTurn, endOpponentTurn, getEligibleMultiTargetJustices } = useCourtTurns(
+    game,
+    campaign,
+    ui,
+    {
+      trackTrialVerdictStats: stats.trackTrialVerdictStats,
+      applyTactic: (t, j, a) => applyTactic(t, j, a),
+      shuffle,
+      triggerLemonMomentIfDue,
+    },
+  );
+
+  // ─── Go To The Lectern Without Notes (composable) ────────────
+
+  const { enterLecternMode, chooseLecternCard, applyLecternBoost } = useCourtLectern(game, {
+    drawCard,
+    removeFromPlaybook,
+    shuffle,
+    endPlayerTurn,
+    initiateTactic: (tactic) => initiateTactic(tactic),
+    recordPlay: (play) => courtReport.plays.push(play),
+  });
+
   // ─── UI Helpers (composable) ─────────────────────────────────
 
   const { voteMeterStyle, verdictJusticeBarStyle, justiceVoteHistory } = useCourtHelpers(game, caseHistory);
+
+  // True whenever the hand should be shown face-down: while picking a blind card, and while a
+  // committed blind card still awaits its target (so the unchosen cards can't be deduced).
+  const lecternConcealed = computed(() => game.lecternMode || game.lecternBlindTacticId !== null);
+
+  // Justices that the currently-staged tactic cannot legally target. The bench dims these and
+  // makes them non-interactive so it's obvious where an argument can (and can't) land — rather
+  // than silently doing nothing when an invalid justice is clicked.
+  const untargetableJusticeIds = computed<Set<number>>(() => {
+    const blocked = new Set<number>();
+
+    if (game.selectedTacticId !== null) {
+      const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.selectedTacticId);
+      if (tactic?.effectType === "shield") {
+        // Shield protects an ally — only justices already leaning your way are valid.
+        game.bench.forEach((j) => (game.leanings[j.id] ?? 0) <= 0 && blocked.add(j.id));
+      } else if (tactic?.effectType === "betray-friend") {
+        // Betray needs a Strongly For justice (≥ 60) to sacrifice.
+        game.bench.forEach((j) => (game.leanings[j.id] ?? 0) < 60 && blocked.add(j.id));
+      }
+      return blocked;
+    }
+
+    if (game.multiTargetMode) {
+      const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === game.multiTargetTacticId) ?? null;
+      const eligible = new Set(getEligibleMultiTargetJustices(tactic).map((j) => j.id));
+      game.bench.forEach((j) => !eligible.has(j.id) && blocked.add(j.id));
+    }
+
+    return blocked;
+  });
 
   // ─── Game Management ─────────────────────────────────────────
 
@@ -530,6 +452,9 @@
     game.reframeStanceChoices = [];
     game.reframeStanceTacticId = null;
     game.reframeStanceSelection = null;
+    game.lecternMode = false;
+    game.lecternBoostPending = false;
+    game.lecternBlindTacticId = null;
     trialAttackedJustices.clear();
     courtReport.plays = [];
     ui.phase = "setup";
@@ -561,7 +486,7 @@
     trialAttackedJustices.clear();
     ui.phase = "playing";
     if (!ui.isCampaignMode) {
-      void trackQuickplayStarted();
+      void stats.trackQuickplayStarted();
     }
   }
 
@@ -606,7 +531,16 @@
   function selectTactic(tacticId: number): void {
     if (game.currentTurn !== "player" || ui.opponentThinking) return;
 
+    // While at the lectern, every click is a blind pick — route it through the lectern handler.
+    if (game.lecternMode) {
+      chooseLecternCard(tacticId);
+      return;
+    }
+
     if (game.claimingMode) {
+      // The Lectern card can't be claimed — it's a blind gamble, not a stashable tactic.
+      const clicked = game.playbook.find((t) => t.id === tacticId);
+      if (clicked?.effectType === "lectern-without-notes") return;
       const idx = game.claimedSelections.indexOf(tacticId);
       if (idx !== -1) {
         game.claimedSelections.splice(idx, 1);
@@ -617,6 +551,10 @@
       return;
     }
 
+    // A blind card is committed and awaiting its target — it's locked in. No deselecting,
+    // no swapping to another card. Committing blind is the whole risk; you can't wriggle out.
+    if (game.lecternBlindTacticId !== null) return;
+
     if (game.multiTargetMode && game.multiTargetTacticId === tacticId) {
       clearMultiTargetMode();
       return;
@@ -624,6 +562,15 @@
 
     const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === tacticId);
     if (!tactic) return;
+
+    initiateTactic(tactic);
+  }
+
+  function initiateTactic(tactic: Tactic): InitiateResult {
+    if (tactic.effectType === "lectern-without-notes") {
+      enterLecternMode(tactic);
+      return "lectern";
+    }
 
     if (
       tactic.effectType === "sway-all" ||
@@ -643,35 +590,41 @@
       tactic.effectType === "international-law"
     ) {
       applyTactic(tactic, null, "player");
+      return "resolved";
     } else if (tactic.effectType === "claim-two") {
-      if (game.claimedCards.length > 0) return;
+      if (game.claimedCards.length > 0) return "blocked";
       game.playbook = game.playbook.filter((t) => t.id !== tactic.id);
       game.discardPile.push(tactic);
       game.claimingMode = true;
       game.claimedSelections = [];
+      return "targeting";
     } else if (tactic.effectType === "betray-friend") {
       const hasStrongAllyNow = game.bench.some((j) => (game.leanings[j.id] ?? 0) >= 60);
-      if (!hasStrongAllyNow) return;
-      game.selectedTacticId = game.selectedTacticId === tacticId ? null : tacticId;
+      if (!hasStrongAllyNow) return "blocked";
+      game.selectedTacticId = game.selectedTacticId === tactic.id ? null : tactic.id;
+      return "targeting";
     } else if (tactic.effectType === "swap-clerks") {
-      if (game.multiTargetMode) return;
+      if (game.multiTargetMode) return "targeting";
       const eligibleMultiTargetJustices = getEligibleMultiTargetJustices(tactic);
-      if (eligibleMultiTargetJustices.length < 2) return;
+      if (eligibleMultiTargetJustices.length < 2) return "blocked";
       game.selectedTacticId = null;
       game.multiTargetTacticId = tactic.id;
       game.multiTargetMode = true;
       game.multiTargetSelections = [];
+      return "targeting";
     } else if (tactic.effectType === "reframe-debate") {
-      if (game.reframeStanceMode) return;
+      if (game.reframeStanceMode) return "targeting";
       const allBenchStances = new Set<StanceType>();
       game.bench.forEach((j) => j.stances?.forEach((s) => allBenchStances.add(s.topic)));
-      if (allBenchStances.size === 0) return;
+      if (allBenchStances.size === 0) return "blocked";
       const shuffledStances = shuffle([...allBenchStances]);
       game.reframeStanceChoices = shuffledStances.slice(0, 3) as StanceType[];
       game.reframeStanceTacticId = tactic.id;
       game.reframeStanceMode = true;
+      return "targeting";
     } else {
-      game.selectedTacticId = game.selectedTacticId === tacticId ? null : tacticId;
+      game.selectedTacticId = game.selectedTacticId === tactic.id ? null : tactic.id;
+      return "targeting";
     }
   }
 
@@ -690,9 +643,13 @@
       targetName: claimed.map((t) => t.name).join(" & "),
       results: [],
       round: game.round,
+      viaLectern: game.lecternBlindTacticId !== null,
     });
     game.claimingMode = false;
     game.claimedSelections = [];
+    // Dibs moves no leanings, so a pending lectern boost has nothing to act on — clear it.
+    game.lecternBoostPending = false;
+    game.lecternBlindTacticId = null;
     endPlayerTurn();
   }
 
@@ -722,6 +679,8 @@
   }
 
   function cancelReframeStance(): void {
+    // A blindly-committed Reframe is locked in — you can't peek and back out.
+    if (game.lecternBlindTacticId !== null) return;
     game.reframeStanceMode = false;
     game.reframeStanceTacticId = null;
     game.reframeStanceChoices = [];
@@ -794,6 +753,15 @@
   function applyTactic(tactic: Tactic, targetJustice: Justice | null, actor: TurnActor): void {
     const outcome: EffectOutcome = resolveEffect(game, tactic, targetJustice, actor, { drawCard, removeFromPlaybook });
 
+    // "Without notes" payoff: amplify the swings of whatever blind card was committed to.
+    const lecternBoosted = game.lecternBoostPending;
+    if (lecternBoosted) {
+      applyLecternBoost(outcome);
+      game.lecternBoostPending = false;
+    }
+    // The blind card has now resolved (and revealed) — release the lock.
+    game.lecternBlindTacticId = null;
+
     const attackedJusticeNames = getAttackedJusticeNamesForPlay({
       effectType: tactic.effectType,
       targetJusticeName: targetJustice?.name,
@@ -826,9 +794,11 @@
       targetName: outcome.reportTarget,
       results: outcome.results.filter((r) => r.change !== 0),
       round: game.round,
+      viaLectern: lecternBoosted,
     });
 
-    const feedback = outcome.overrideFeedback ?? tactic.feedback ?? null;
+    const baseFeedback = outcome.overrideFeedback ?? tactic.feedback ?? null;
+    const feedback = lecternBoosted ? `🎤 Argued without notes — amplified! ${baseFeedback ?? ""}`.trim() : baseFeedback;
 
     toast(
       {
@@ -847,7 +817,7 @@
       },
     );
 
-    void trackTacticPlay(tactic, actor, outcome.results);
+    void stats.trackTacticPlay(tactic, actor, outcome.results);
 
     if (actor === "player") {
       endPlayerTurn();
@@ -898,14 +868,10 @@
     if (campaignEndLogged || !campaign.data?.isOver || campaign.data.won === null) return;
     campaignEndLogged = true;
 
-    void trackCampaignCompleted(campaign.data.setup.name, campaign.data.won);
+    void stats.trackCampaignCompleted(campaign.data.setup.name, campaign.data.won);
 
     if (campaign.data.activeObjective) {
-      void courtStats.writeObjectiveStats({
-        objectiveName: campaign.data.activeObjective.name,
-        succeeded: campaign.data.won,
-        failed: !campaign.data.won,
-      });
+      stats.trackObjectiveResult(campaign.data.activeObjective.name, campaign.data.won);
     }
   }
 
@@ -914,12 +880,12 @@
 
     if (!campaign.data) return;
     campaignEndLogged = false;
-    void trackCampaignStarted(campaign.data.setup.name);
+    void stats.trackCampaignStarted(campaign.data.setup.name);
   }
 
   function chooseObjective(objective: Parameters<typeof pickObjective>[0]): void {
     pickObjective(objective);
-    void courtStats.writeObjectiveStats({ objectiveName: objective.name, chosen: true });
+    stats.trackObjectiveChosen(objective.name);
   }
 
   function activateDoubleTap(): void {
@@ -928,10 +894,7 @@
     const afterActive = campaign.data?.doubleTapActive ?? false;
 
     if (!beforeActive && afterActive) {
-      void courtStats.writeRewardStats({
-        rewardName: rewardNameFromId("double-tap"),
-        activated: true,
-      });
+      stats.trackRewardActivated(rewardNameFromId("double-tap"));
     }
   }
 
@@ -941,10 +904,7 @@
     const afterActivatedCount = campaign.data?.activatedPreRecessCardIds.length ?? 0;
 
     if (afterActivatedCount > beforeActivatedCount) {
-      void courtStats.writeRewardStats({
-        rewardName: rewardNameFromId(rewardId),
-        activated: true,
-      });
+      stats.trackRewardActivated(rewardNameFromId(rewardId));
     }
   }
 
@@ -965,7 +925,7 @@
       if (beforeCount > 0) {
         beforeRewardCounts.set(reward.id, beforeCount - 1);
       } else {
-        void courtStats.writeRewardStats({ rewardName: reward.name, chosen: true });
+        stats.trackRewardChosen(reward.name);
       }
     });
 

--- a/src/views/court/pug/modals/_court-record.pug
+++ b/src/views/court/pug/modals/_court-record.pug
@@ -20,7 +20,9 @@
             .round-col.round-col--player(:class="{ 'is-pending': !roundData.playerPlay }")
               .round-col__header You
               template(v-if="roundData.playerPlay")
-                .round-col__tactic {{ roundData.playerPlay.tacticName }}
+                .round-col__tactic
+                  | {{ roundData.playerPlay.tacticName }}
+                  span.lectern-badge(v-if="roundData.playerPlay.viaLectern" v-tippy="'Played blind via Go To The Lectern Without Notes — amplified power.'") 🎤 Without Notes
                 .round-col__target → {{ roundData.playerPlay.targetName }}
                 .round-col__results(v-if="roundData.playerPlay.results.length")
                   span.col-result(

--- a/src/views/court/pug/screens/_playing.pug
+++ b/src/views/court/pug/screens/_playing.pug
@@ -67,7 +67,8 @@ main.court-playing(v-if="ui.phase === 'playing'")
           'has-image': justiceImageUrl(justice), \
           'is-ally': (game.leanings[justice.id] ?? 0) > 0, \
           'is-enemy': (game.leanings[justice.id] ?? 0) < 0, \
-          'is-targetable': game.selectedTacticId !== null || game.multiTargetMode, \
+          'is-targetable': (game.selectedTacticId !== null || game.multiTargetMode) && !untargetableJusticeIds.has(justice.id), \
+          'is-untargetable': (game.selectedTacticId !== null || game.multiTargetMode) && untargetableJusticeIds.has(justice.id), \
           'is-shielded': game.playerShields.includes(justice.id), \
           'is-chief': justice.id === game.chiefJusticeId, \
           'is-napping': !!game.nappingJustices[justice.id], \
@@ -138,7 +139,10 @@ main.court-playing(v-if="ui.phase === 'playing'")
         .playbook-meta
           span.deck-count 🃏 {{ game.deck.length }} in deck
           span.claimed-count(v-if="game.claimedCards.length")  · {{ game.claimedCards.length }} claimed by you
-      p.claiming-hint(v-if="game.claimingMode")
+      p.hand-hint.lectern-hint(v-if="game.lecternMode") 🎤 You're at the lectern without notes — pick any card. You won't know what it is until you commit, but it will hit harder than usual.
+      p.hand-hint.lectern-hint(v-else-if="game.lecternBlindTacticId !== null && game.claimingMode") 🎤 Surprise — it was I Call Dibs! Pick {{ 2 - game.claimedSelections.length }} more card(s) to claim. Still face-down, still a mystery.
+      p.hand-hint.lectern-hint(v-else-if="game.lecternBlindTacticId !== null") 🎤 Locked in, sight unseen — now choose your target{{ game.multiTargetMode ? 's' : '' }}. You'll find out what you played when it lands.
+      p.claiming-hint(v-else-if="game.claimingMode")
         | Select {{ 2 - game.claimedSelections.length }} more card(s) to claim for your exclusive use.
       p.hand-hint(v-else-if="game.multiTargetMode") 👆 Select {{ 2 - game.multiTargetSelections.length }} more justice{{ (2 - game.multiTargetSelections.length) === 1 ? '' : 's' }} above
       p.hand-hint(v-else-if="game.selectedTacticId !== null") ↑ Click a justice above to target them
@@ -155,17 +159,22 @@ main.court-playing(v-if="ui.phase === 'playing'")
             { \
               'is-selected': game.selectedTacticId === tactic.id || game.multiTargetTacticId === tactic.id, \
               'is-claimed': true, \
-              'is-disabled': tactic.effectType === 'betray-friend' && !hasStrongAlly, \
+              'is-disabled': !lecternConcealed && tactic.effectType === 'betray-friend' && !hasStrongAlly, \
+              'is-face-down': lecternConcealed, \
             } \
           ]"
           @click="selectTactic(tactic.id)"
         )
-          .tc__type {{ tactic.cardType }} · claimed
-          .tc__name {{ tactic.name }}
-          .tc__flavor {{ tactic.flavorText }}
-          .tc__meta
-            span.tc__target {{ targetLabel(tactic.effectType) }}
-            span.tc__power(v-if="tactic.basePower > 0")  ⚡{{ tactic.basePower }}
+          template(v-if="lecternConcealed")
+            .tc__back ❔
+            .tc__back-label Mystery Tactic
+          template(v-else)
+            .tc__type {{ tactic.cardType }} · claimed
+            .tc__name {{ tactic.name }}
+            .tc__flavor {{ tactic.flavorText }}
+            .tc__meta
+              span.tc__target {{ targetLabel(tactic.effectType) }}
+              span.tc__power(v-if="tactic.basePower > 0")  ⚡{{ tactic.basePower }}
 
 
     //- Shared playbook cards
@@ -181,18 +190,23 @@ main.court-playing(v-if="ui.phase === 'playing'")
               'is-selected': game.selectedTacticId === tactic.id || game.multiTargetTacticId === tactic.id, \
               'is-claiming-pick': game.claimingMode && game.claimedSelections.includes(tactic.id), \
               'is-opponent-browsing': ui.opponentHighlightedCardId === tactic.id, \
-              'is-disabled': tactic.effectType === 'betray-friend' && !hasStrongAlly, \
+              'is-disabled': !lecternConcealed && ((tactic.effectType === 'betray-friend' && !hasStrongAlly) || (game.claimingMode && tactic.effectType === 'lectern-without-notes')), \
+              'is-face-down': lecternConcealed, \
             } \
           ]"
           @click="selectTactic(tactic.id)"
         )
-          .tc__type {{ tactic.cardType }}
-          .tc__name {{ tactic.name }}
-          .tc__description {{ tactic.description }}
-          .tc__flavor {{ tactic.flavorText }}
-          .tc__meta
-            span.tc__target {{ targetLabel(tactic.effectType) }}
-            span.tc__power(v-if="tactic.basePower > 0")  ⚡{{ tactic.basePower }}
+          template(v-if="lecternConcealed")
+            .tc__back ❔
+            .tc__back-label Mystery Tactic
+          template(v-else)
+            .tc__type {{ tactic.cardType }}
+            .tc__name {{ tactic.name }}
+            .tc__description {{ tactic.description }}
+            .tc__flavor {{ tactic.flavorText }}
+            .tc__meta
+              span.tc__target {{ targetLabel(tactic.effectType) }}
+              span.tc__power(v-if="tactic.basePower > 0")  ⚡{{ tactic.basePower }}
   //- ── OPPONENT THINKING OVERLAY ────────────────────────────────
   .opponent-thinking-overlay(v-if="ui.opponentThinking")
     .otl-message
@@ -222,4 +236,4 @@ main.court-playing(v-if="ui.phase === 'playing'")
           span.rs-stance-counts
             span.rs-for(v-if="info.forCount" v-tippy="`${info.forCount} justices are FOR this — they will warm to you`") ▲{{ info.forCount }}
             span.rs-against(v-if="info.againstCount" v-tippy="`${info.againstCount} justices are AGAINST this — they will lean away`") ▼{{ info.againstCount }}
-      button.btn.btn--text(@click="cancelReframeStance()") Cancel
+      button.btn.btn--text(v-if="game.lecternBlindTacticId === null" @click="cancelReframeStance()") Cancel

--- a/src/views/court/scss/modals/_court-record.scss
+++ b/src/views/court/scss/modals/_court-record.scss
@@ -172,6 +172,20 @@ $cr-opponent-negative: #e96262;
     margin-bottom: 0.15rem;
   }
 
+  .lectern-badge {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.08rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.62rem;
+    font-weight: $bold;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
+    color: #2a2208;
+    background: $court-gold;
+    vertical-align: middle;
+  }
+
   .round-col__target {
     font-size: 0.73rem;
     opacity: 0.6;

--- a/src/views/court/scss/screens/_playing.scss
+++ b/src/views/court/scss/screens/_playing.scss
@@ -239,6 +239,15 @@
   .justice-card.is-enemy {
     border-color: $court-red;
   }
+
+  // Not a legal target for the staged tactic — dimmed and non-interactive, mirroring
+  // how an unplayable tactic card reads as disabled.
+  .justice-card.is-untargetable {
+    opacity: 0.32;
+    filter: grayscale(0.65);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 
 // ─── The Playbook ───────────────────────────────────────────
@@ -411,6 +420,42 @@
   &.card-type-utility {
     border-top: 4px solid $card-type-utility;
   }
+
+  // ── "Without notes" face-down state ──
+  &.is-face-down {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    border-top-color: $court-gold;
+    background:
+      repeating-linear-gradient(45deg, rgba(201, 168, 76, 0.12) 0 10px, transparent 10px 20px),
+      $court-card;
+
+    &:hover {
+      border-color: $court-gold;
+      box-shadow: 0 8px 24px rgba(201, 168, 76, 0.5);
+    }
+  }
+}
+
+.tc__back {
+  font-size: 2.6rem;
+  line-height: 1;
+  margin: 0.6rem 0 0.2rem;
+}
+
+.tc__back-label {
+  font-family: $serif;
+  font-size: 0.82rem;
+  font-weight: $bold;
+  letter-spacing: 0.04em;
+  color: $court-gold;
+  padding-bottom: 0.5rem;
+}
+
+.lectern-hint {
+  color: $court-gold;
+  font-weight: $bold;
 }
 
 .tc__type {

--- a/src/views/court/ts/_campaigns.ts
+++ b/src/views/court/ts/_campaigns.ts
@@ -1,5 +1,5 @@
 import type { CampaignSetup } from "./_types";
-import { PRES_TRUMP, PRES_NIXON, PRES_OBAMA, PRES_BIDEN, PRES_EISENHOWER, PRES_LBJ, PRES_SNOOP_DOGG, PRES_VERMIN_SUPREME } from "./_presidents";
+import { PRES_TRUMP, PRES_NIXON, PRES_OBAMA, PRES_SNOOP_DOGG, PRES_VERMIN_SUPREME } from "./_presidents";
 
 /**
  * Pre-defined campaign configurations.

--- a/src/views/court/ts/_tactics.ts
+++ b/src/views/court/ts/_tactics.ts
@@ -1,20 +1,9 @@
 import { Tactic } from "./_types";
 
 export const tactics: Tactic[] = [
-  // ─── ATTACKS ──────────────────────────────────────────────────────
+  // ─── ATTACK JUSTICE ──────────────────────────────────────────────────────
+  // cards in this section will focus on swaying a single justice to your side.
 
-  {
-    id: 1,
-    name: "Cite Precedents",
-    description:
-      "Sways all justices. High-logic justices are strongly persuaded; they respect a citation. Low-logic justices are actively offended you brought up authority and lean harder the other way.",
-    flavorText: "Citing cases no one in the room has read since law school, loudly.",
-    cardType: "attack",
-    effectType: "sway-all",
-    basePower: 4,
-    statBasis: "logic",
-    statRelation: "polarizes-high",
-  },
   {
     id: 2,
     name: "Emotional Appeal",
@@ -58,7 +47,6 @@ export const tactics: Tactic[] = [
     basePower: 7,
     weaknessBasis: "threats",
   },
-
   {
     id: 7,
     name: "Shameless Flattery",
@@ -68,6 +56,71 @@ export const tactics: Tactic[] = [
     effectType: "sway-one",
     basePower: 8,
     weaknessBasis: "flattery",
+  },
+  {
+    id: 19,
+    name: "Betray Your Friend",
+    description:
+      "Target a justice Strongly For you. They flip to Strongly Against. Opposing-party justices currently leaning against you may rally to your side as a result.",
+    flavorText: "I've always believed the strongest legal strategy is the one where you stab your biggest fan in the face.",
+    cardType: "attack",
+    effectType: "betray-friend",
+    basePower: 0,
+  },
+  {
+    id: 38,
+    name: "Whisper Campaign",
+    description:
+      "Target one justice. They shift toward you by a small amount at the start of every remaining round (including this one). Most effective when played Round 1 (affects all 5 rounds); minimal impact when played Round 5.",
+    flavorText: "Rumors and quiet influence take time to percolate through the legal community. Early whispers pay compound dividends.",
+    cardType: "attack",
+    effectType: "whisper-campaign",
+    basePower: 2,
+  },
+  {
+    id: 22,
+    name: "Order Drinks For A Justice",
+    description:
+      "Target a justice. Their charisma, empathy, and susceptibility rise for the rest of the trial while their logic drops. They also slide meaningfully toward you right now.",
+    flavorText: "The Heritage Foundation gala was an open bar. One justice in particular should not have had that fourth beer. You know who you are.",
+    cardType: "utility",
+    effectType: "justice-cocktails",
+    basePower: 0,
+  },
+  {
+    id: 30,
+    name: "Plant A Story",
+    description: "Target one justice. Their party loyalty spikes for the rest of the trial and they immediately react to the sudden media pressure.",
+    flavorText: "The headline writes itself: 'Justices Under Fire From Own Party.' Nobody reads it. Everyone sees it.",
+    cardType: "utility",
+    effectType: "plant-story",
+    basePower: 0,
+    feedback: "That justice suddenly feels their party breathing down their neck.",
+  },
+  {
+    id: 33,
+    name: "Yaaas! Drag Them!",
+    description:
+      "Publicly air a justice's worst qualities. Their charisma takes a permanent hit. If they're weak to threats, they'll also slide in your direction. If they're immune to threats, they won't appreciate it.",
+    flavorText: "The tweet had 80,000 likes. The justice saw it. The justice is... processing.",
+    cardType: "attack",
+    effectType: "drag-them",
+    basePower: 0,
+  },
+
+  // --- ATTACK BENCH -------------------------------------------------
+  // cards in this section will sway the entire bench one way or another.
+  {
+    id: 1,
+    name: "Cite Precedents",
+    description:
+      "Sways all justices. High-logic justices are strongly persuaded; they respect a citation. Low-logic justices are actively offended you brought up authority and lean harder the other way.",
+    flavorText: "Citing cases no one in the room has read since law school, loudly.",
+    cardType: "attack",
+    effectType: "sway-all",
+    basePower: 4,
+    statBasis: "logic",
+    statRelation: "polarizes-high",
   },
   {
     id: 8,
@@ -100,65 +153,36 @@ export const tactics: Tactic[] = [
     effectType: "request-amicus",
     basePower: 1,
   },
-
-  // ─── DEFENSE ──────────────────────────────────────────────────────
-
   {
-    id: 11,
-    name: "Redirect the Witness",
-    description: "Shields one allied justice from the next opposing effect. Must target a justice already on your side.",
-    flavorText: "I'd like to redirect the court's attention to something completely different. Over there. No, there.",
-    cardType: "defense",
-    effectType: "shield",
-    basePower: 0,
-  },
-
-  // ─── UTILITY ──────────────────────────────────────────────────────
-
-  // ─── DOCKET MANIPULATION ──────────────────────────────────────────
-
-  {
-    id: 13,
-    name: "Purge the Record",
-    description: "Discard all 5 cards in the Playbook and draw 5 fresh ones. If opposing counsel was quietly counting on any of those cards, that's a shame.",
-    flavorText: "Motion to strike everything. The whole thing. Yes, the precedent too. Especially the precedent.",
-    cardType: "utility",
-    effectType: "discard-all",
-    basePower: 0,
-    feedback: "The Playbook has been cleared.",
-  },
-  {
-    id: 14,
-    name: "I Call Dibs",
+    id: 29,
+    name: "Gift Boxes Of Ferrero Rocher",
     description:
-      "Select 2 cards from the Playbook to claim exclusively. Opposing counsel can no longer play them. You must still play them yourself. Only usable while you have no active Dibs.",
-    flavorText: "Objection, Your Honor. Those cards were mine spiritually before my client could lose.",
-    cardType: "defense",
-    effectType: "claim-two",
-    basePower: 0,
-  },
-
-  // ─── CHIEF JUSTICE INTERACTION ────────────────────────────────
-
-  {
-    id: 15,
-    name: "Elevate to Chief",
-    description:
-      "Appoint a justice as Chief. They warm to you immediately. The prior Chief and their partisan allies are displeased, and the new Chief loses their sway resistance.",
-    flavorText: "With all due respect to the current Chief, I'd like to propose a restructuring.",
-    cardType: "utility",
-    effectType: "make-chief",
-    basePower: 0,
-  },
-  {
-    id: 16,
-    name: "Bench Roast",
-    description:
-      "Deliver a scathing insult to the Chief Justice directly. They'll take it personally. Every justice with a different party affiliation will enjoy it immensely.",
-    flavorText: "Some say a judge's reputation speaks louder than their rulings. In this case, both are embarrassing.",
+      "Bribery-susceptible justices (6+) are swayed in your favor. Bribery-resistant justices (3 or lower) are deeply offended and lean against you. Others are unmoved by the gesture.",
+    flavorText: "A handwritten note read: 'These are just chocolates. Enjoy.' The envelope inside said something slightly different.",
     cardType: "attack",
-    effectType: "insult-chief",
-    basePower: 5,
+    effectType: "gift-boxes",
+    basePower: 0,
+  },
+  {
+    id: 37,
+    name: "Turn On The Fog Machine",
+    description:
+      "Sways all justices based on how decided they are. Neutral justices (within ±10 leaning) are swayed more strongly. Strongly decided justices (beyond ±40) are annoyed by the disruption and lean slightly away.",
+    flavorText:
+      "The attorney turns on a literal fog machine in the courtroom, as well as some gel lights, introducing 'razzle dazzle' and perking up any justice who was bored. Strongly leaning justices are annoyed by the disruption.",
+    cardType: "attack",
+    effectType: "fog-machine",
+    basePower: 2,
+  },
+  {
+    id: 39,
+    name: "Tell A Story Of Alien Abduction",
+    description:
+      "All justices with Susceptibility 7+ are swayed toward you (they'll believe anything). Justices with Susceptibility 4 or below are offended by the absurdity and lean away.",
+    flavorText: "You argue something dubious, frankly stupid, and only susceptible justices fall for it.",
+    cardType: "attack",
+    effectType: "alien-abduction",
+    basePower: 6,
   },
   {
     id: 17,
@@ -172,60 +196,16 @@ export const tactics: Tactic[] = [
     requiresTrumpNominee: true,
   },
   {
-    id: 18,
-    name: "Recuse Yourself!",
-    description: "Force a targeted justice to recuse — their leaning resets to neutral. While recused, incoming sway against them is cut roughly in half.",
-    flavorText: "There are no conflicts of interest here. There are only interests.",
-    cardType: "utility",
-    effectType: "recuse",
-    basePower: 0,
-  },
-
-  // ─── ADVANCED ATTACKS ─────────────────────────────────────────
-
-  {
-    id: 19,
-    name: "Betray Your Friend",
+    id: 41,
+    name: "Cite International Law",
     description:
-      "Target a justice Strongly For you. They flip to Strongly Against. Opposing-party justices currently leaning against you may rally to your side as a result.",
-    flavorText: "I've always believed the strongest legal strategy is the one where you stab your biggest fan in the face.",
+      "High-party-loyalty justices (7+) are offended and lean away; low-party-loyalty independents (4 or below) are intrigued and lean toward you. Mid-loyalty justices unaffected.",
+    flavorText:
+      "'The European Court of Human Rights says...' — triggers partisan knee-jerk reactions. Independents appreciate the global perspective; partisans see it as foreign meddling.",
     cardType: "attack",
-    effectType: "betray-friend",
-    basePower: 0,
+    effectType: "international-law",
+    basePower: 5,
   },
-
-  // ─── ADVANCED UTILITY ─────────────────────────────────────────
-
-  {
-    id: 20,
-    name: "Swap Clerks",
-    description: "Select two justices. Their leanings swap entirely. The clerks are very good at their jobs.",
-    flavorText: "Law clerks are overworked, underpaid, and know exactly where everything is.",
-    cardType: "utility",
-    effectType: "swap-clerks",
-    basePower: 0,
-  },
-  {
-    id: 21,
-    name: "Encourage A Nap",
-    description:
-      "Select a justice. They skip the next round entirely — no one can sway them. When they wake up, they return with a +15 leaning boost toward you.",
-    flavorText: "Oral arguments are dense, the room is warm, and this man ate a very large lunch. Sometimes you help.",
-    cardType: "utility",
-    effectType: "encourage-nap",
-    basePower: 0,
-  },
-  {
-    id: 22,
-    name: "Order Drinks For A Justice",
-    description:
-      "Target a justice. Their charisma, empathy, and susceptibility rise for the rest of the trial while their logic drops. They also slide meaningfully toward you right now.",
-    flavorText: "The Heritage Foundation gala was an open bar. One justice in particular should not have had that fourth beer. You know who you are.",
-    cardType: "utility",
-    effectType: "justice-cocktails",
-    basePower: 0,
-  },
-
   {
     id: 24,
     name: "Celebrate St. Patrick's Day",
@@ -246,8 +226,58 @@ export const tactics: Tactic[] = [
     effectType: "invite-church",
     basePower: 0,
   },
-  // ─── NEW CARDS ────────────────────────────────────────────────────────────
+  {
+    id: 36,
+    name: "Recite The Dissent",
+    description: "For each justice currently voting against you, all justices currently voting for you receive a small additional sway toward your side.",
+    flavorText: "You read the whole thing out loud. All 47 pages.",
+    cardType: "attack",
+    effectType: "recite-dissent",
+    basePower: 0,
+  },
 
+  // ─── DEFENSE ──────────────────────────────────────────────────────
+  // cards in this section are primarily interested in protecting one or more judges from future attacks.
+  {
+    id: 11,
+    name: "Redirect the Witness",
+    description: "Shields one allied justice from the next opposing effect. Must target a justice already on your side.",
+    flavorText: "I'd like to redirect the court's attention to something completely different. Over there. No, there.",
+    cardType: "defense",
+    effectType: "shield",
+    basePower: 0,
+  },
+  {
+    id: 21,
+    name: "Encourage A Nap",
+    description:
+      "Select a justice. They skip the next round entirely — no one can sway them. When they wake up, they return with a +15 leaning boost toward you.",
+    flavorText: "Oral arguments are dense, the room is warm, and this man ate a very large lunch. Sometimes you help.",
+    cardType: "utility",
+    effectType: "encourage-nap",
+    basePower: 0,
+  },
+  {
+    id: 18,
+    name: "Recuse Yourself!",
+    description: "Force a targeted justice to recuse — their leaning resets to neutral. While recused, incoming sway against them is cut roughly in half.",
+    flavorText: "There are no conflicts of interest here. There are only interests.",
+    cardType: "utility",
+    effectType: "recuse",
+    basePower: 0,
+  },
+
+  // ─── UTILITY ─────────────────────────────────────────
+  // cards in this section have a variety of effects. This is basically the "doesn't fit any category" section.
+  {
+    id: 20,
+    name: "Swap Clerks",
+    description: "Select two justices. Their leanings swap entirely. The clerks are very good at their jobs.",
+    flavorText: "Law clerks are overworked, underpaid, and know exactly where everything is.",
+    cardType: "utility",
+    effectType: "swap-clerks",
+    basePower: 0,
+  },
   {
     id: 28,
     name: "Reframe The Debate",
@@ -258,20 +288,88 @@ export const tactics: Tactic[] = [
     effectType: "reframe-debate",
     basePower: 0,
   },
-
   {
-    id: 29,
-    name: "Gift Boxes Of Ferrero Rocher",
+    id: 40,
+    name: "Mess With The Calendar",
     description:
-      "Bribery-susceptible justices (6+) are swayed in your favor. Bribery-resistant justices (3 or lower) are deeply offended and lean against you. Others are unmoved by the gesture.",
-    flavorText: "A handwritten note read: 'These are just chocolates. Enjoy.' The envelope inside said something slightly different.",
-    cardType: "attack",
-    effectType: "gift-boxes",
+      "You AND your opponent both skip the next round entirely. The trial advances to the next round without arguments from either side. Closing tactic when you're ahead and want the trial to end without more sways.",
+    flavorText: "You edit the Microsoft Calendar to delete one of the trial days. Court does not take place that day.",
+    cardType: "utility",
+    effectType: "mess-calendar",
+    basePower: 0,
+    feedback: "The calendar has been... adjusted. Both sides skip the next round.",
+  },
+  {
+    id: 31,
+    name: "Invoke The Lemon Test",
+    description:
+      "Cite Lemon v. Kurtzman, loudly. All justices become irreligious for the rest of the trial and gain a slight logic boost. Has no effect on justices already deeply uncomfortable with religion.",
+    flavorText: "The Establishment Clause enters the chat. The church-going bloc checks their watches.",
+    cardType: "utility",
+    effectType: "lemon-test",
+    basePower: 0,
+    feedback: "All justices are temporarily irreligious. Their logic has improved accordingly.",
+  },
+
+  // ─── PLAYBOOK MANIPULATION ──────────────────────────────────────────
+  // cards in this section do SOMETHING to the playbook specifically
+  {
+    id: 13,
+    name: "Purge the Record",
+    description: "Discard all 5 cards in the Playbook and draw 5 fresh ones. If opposing counsel was quietly counting on any of those cards, that's a shame.",
+    flavorText: "Motion to strike everything. The whole thing. Yes, the precedent too. Especially the precedent.",
+    cardType: "utility",
+    effectType: "discard-all",
+    basePower: 0,
+    feedback: "The Playbook has been cleared.",
+  },
+  {
+    id: 42,
+    name: "Go To The Lectern Without Notes",
+    description:
+      "Flip the entire Playbook face-down, draw a fresh card, and shuffle the lot. Pick one blind — you won't know what it is until you commit. Whatever you play comes out swinging far harder than it normally would.",
+    flavorText: "No notes. No outline. No plan. Just raw confidence and whatever falls out of your mouth. The justices can smell the adrenaline.",
+    cardType: "utility",
+    effectType: "lectern-without-notes",
+    basePower: 0,
+    feedback: "You stride to the lectern with nothing in your hands. Pick a card — any card.",
+  },
+  {
+    id: 14,
+    name: "I Call Dibs",
+    description:
+      "Select 2 cards from the Playbook to claim exclusively. Opposing counsel can no longer play them. You must still play them yourself. Only usable while you have no active Dibs.",
+    flavorText: "Objection, Your Honor. Those cards were mine spiritually before my client could lose.",
+    cardType: "defense",
+    effectType: "claim-two",
     basePower: 0,
   },
+
+  // ─── CHIEF JUSTICE INTERACTION ────────────────────────────────
+  // cards in this section are focused on whoever the chief custice is
+  {
+    id: 15,
+    name: "Elevate to Chief",
+    description:
+      "Appoint a justice as Chief. They warm to you immediately. The prior Chief and their partisan allies are displeased, and the new Chief loses their sway resistance.",
+    flavorText: "With all due respect to the current Chief, I'd like to propose a restructuring.",
+    cardType: "utility",
+    effectType: "make-chief",
+    basePower: 0,
+  },
+  {
+    id: 16,
+    name: "Bench Roast",
+    description:
+      "Deliver a scathing insult to the Chief Justice directly. They'll take it personally. Every justice with a different party affiliation will enjoy it immensely.",
+    flavorText: "Some say a judge's reputation speaks louder than their rulings. In this case, both are embarrassing.",
+    cardType: "attack",
+    effectType: "insult-chief",
+    basePower: 5,
+  },
+
   // ─── CAMPAIGN-ONLY TACTICS ────────────────────────────────────────────
   // These cards have campaignOnly: true and will NEVER appear in Quick Play decks.
-
   {
     id: 26,
     name: "Suggest Retirement",
@@ -295,125 +393,5 @@ export const tactics: Tactic[] = [
     basePower: 0,
     campaignOnly: true,
     feedback: "The new Chief Justice's appointment is now permanent.",
-  },
-
-  // ─── NEW TACTICS ───────────────────────────────────────────────────────────
-
-  {
-    id: 30,
-    name: "Plant A Story",
-    description: "Target one justice. Their party loyalty spikes for the rest of the trial and they immediately react to the sudden media pressure.",
-    flavorText: "The headline writes itself: 'Justices Under Fire From Own Party.' Nobody reads it. Everyone sees it.",
-    cardType: "utility",
-    effectType: "plant-story",
-    basePower: 0,
-    feedback: "That justice suddenly feels their party breathing down their neck.",
-  },
-  {
-    id: 31,
-    name: "Invoke The Lemon Test",
-    description:
-      "Cite Lemon v. Kurtzman, loudly. All justices become irreligious for the rest of the trial and gain a slight logic boost. Has no effect on justices already deeply uncomfortable with religion.",
-    flavorText: "The Establishment Clause enters the chat. The church-going bloc checks their watches.",
-    cardType: "utility",
-    effectType: "lemon-test",
-    basePower: 0,
-    feedback: "All justices are temporarily irreligious. Their logic has improved accordingly.",
-  },
-  // {
-  //   id: 32,
-  //   name: "Suggest Yoga",
-  //   description:
-  //     "Politely suggest a justice step away for some mindfulness. They skip the next round. When they return, their empathy and susceptibility are permanently raised for the rest of the trial.",
-  //   flavorText: "'Have you considered a quick flow before deliberations?' They have not. They will now.",
-  //   cardType: "utility",
-  //   effectType: "suggest-yoga",
-  //   basePower: 0,
-  // },
-  {
-    id: 33,
-    name: "Yaaas! Drag Them!",
-    description:
-      "Publicly air a justice's worst qualities. Their charisma takes a permanent hit. If they're weak to threats, they'll also slide in your direction. If they're immune to threats, they won't appreciate it.",
-    flavorText: "The tweet had 80,000 likes. The justice saw it. The justice is... processing.",
-    cardType: "attack",
-    effectType: "drag-them",
-    basePower: 0,
-  },
-  // {
-  //   id: 34,
-  //   name: "Catch A Justice On Their Phone",
-  //   description:
-  //     "Target one justice. Their attention drifts and they become less susceptible for the rest of the trial. They also lean slightly away from your argument in the moment.",
-  //   flavorText: "They weren't taking notes. They were texting.",
-  //   cardType: "utility",
-  //   effectType: "catch-phone",
-  //   basePower: 0,
-  // },
-  {
-    id: 36,
-    name: "Recite The Dissent",
-    description:
-      "No target. For each justice currently voting against you, all justices currently voting for you receive a small additional sway toward your side.",
-    flavorText: "You read the whole thing out loud. All 47 pages.",
-    cardType: "attack",
-    effectType: "recite-dissent",
-    basePower: 0,
-  },
-
-  // ─── PHASE 2 NEW CARDS ────────────────────────────────────────────────────
-
-  {
-    id: 37,
-    name: "Turn On The Fog Machine",
-    description:
-      "Sways all justices based on how decided they are. Neutral justices (within ±10 leaning) are swayed more strongly. Strongly decided justices (beyond ±40) are annoyed by the disruption and lean slightly away.",
-    flavorText:
-      "The attorney turns on a literal fog machine in the courtroom, as well as some gel lights, introducing 'razzle dazzle' and perking up any justice who was bored. Strongly leaning justices are annoyed by the disruption.",
-    cardType: "attack",
-    effectType: "fog-machine",
-    basePower: 2,
-  },
-  {
-    id: 38,
-    name: "Whisper Campaign",
-    description:
-      "Target one justice. They shift toward you by a small amount at the start of every remaining round (including this one). Most effective when played Round 1 (affects all 5 rounds); minimal impact when played Round 5.",
-    flavorText: "Rumors and quiet influence take time to percolate through the legal community. Early whispers pay compound dividends.",
-    cardType: "attack",
-    effectType: "whisper-campaign",
-    basePower: 2,
-  },
-  {
-    id: 39,
-    name: "Tell A Story Of Alien Abduction",
-    description:
-      "All justices with Susceptibility 7+ are swayed toward you (they'll believe anything). Justices with Susceptibility 4 or below are offended by the absurdity and lean away.",
-    flavorText: "You argue something dubious, frankly stupid, and only susceptible justices fall for it.",
-    cardType: "attack",
-    effectType: "alien-abduction",
-    basePower: 6,
-  },
-  {
-    id: 40,
-    name: "Mess With The Calendar",
-    description:
-      "You AND your opponent both skip the next round entirely. The trial advances to the next round without arguments from either side. Closing tactic when you're ahead and want the trial to end without more sways.",
-    flavorText: "You edit the Microsoft Calendar to delete one of the trial days. Court does not take place that day.",
-    cardType: "utility",
-    effectType: "mess-calendar",
-    basePower: 0,
-    feedback: "The calendar has been... adjusted. Both sides skip the next round.",
-  },
-  {
-    id: 41,
-    name: "Cite International Law",
-    description:
-      "High-party-loyalty justices (7+) are offended and lean away; low-party-loyalty independents (4 or below) are intrigued and lean toward you. Mid-loyalty justices unaffected.",
-    flavorText:
-      "'The European Court of Human Rights says...' — triggers partisan knee-jerk reactions. Independents appreciate the global perspective; partisans see it as foreign meddling.",
-    cardType: "attack",
-    effectType: "international-law",
-    basePower: 5,
   },
 ];

--- a/src/views/court/ts/_types.ts
+++ b/src/views/court/ts/_types.ts
@@ -252,7 +252,8 @@ export type TacticEffectType =
   | "whisper-campaign" // target one justice; they are swayed every remaining round
   | "alien-abduction" // sway all justices based on susceptibility (high believe it, low offended)
   | "mess-calendar" // both player and opponent skip the next round
-  | "international-law"; // sway all justices polarized by party loyalty (partisans offended, independents intrigued)
+  | "international-law" // sway all justices polarized by party loyalty (partisans offended, independents intrigued)
+  | "lectern-without-notes"; // flip the playbook face-down, redraw + reshuffle, then play a blind card at amplified power
 
 export interface Tactic {
   id: number;
@@ -321,4 +322,8 @@ export interface CourtGameState {
   whisperCampaigns?: Record<number, { actor: TurnActor; power: number }>; // justiceId → ongoing whisper campaign
   // ── Mess With The Calendar ───────────────────────────────────
   skipNextRound?: boolean; // true when Mess With The Calendar has been played
+  // ── Go To The Lectern Without Notes ──────────────────────────
+  lecternMode: boolean; // true while the playbook is face-down and the player is picking a blind card
+  lecternBoostPending: boolean; // true once a blind card is chosen; the next resolved play is amplified
+  lecternBlindTacticId: number | null; // the committed blind card — stays face-down and locked while it awaits a target
 }

--- a/src/views/court/ts/_useCourtHelpers.ts
+++ b/src/views/court/ts/_useCourtHelpers.ts
@@ -96,6 +96,7 @@ export function targetLabel(effectType: Tactic["effectType"]): string {
       "international-law": "🌍 All justices",
       "reframe-debate": "📣 Choose a stance",
       "suggest-yoga": "🧘 Single target",
+      "lectern-without-notes": "🎤 Blind gamble",
     }[effectType] ?? effectType
   );
 }

--- a/src/views/court/ts/_useCourtLectern.ts
+++ b/src/views/court/ts/_useCourtLectern.ts
@@ -1,0 +1,168 @@
+import type { CourtGameState, Justice, Tactic, TurnActor } from "./_types";
+import type { EffectOutcome } from "./_tacticEffects";
+import { useToast, POSITION } from "vue-toastification";
+import TacticToast from "../components/TacticToast.vue";
+import { uiSettings } from "./_settings";
+
+// Boost applied to whatever blind card the player commits to. Tweak freely.
+export const LECTERN_BOOST = 1.6;
+
+// Outcome of trying to start playing a tactic. Shared with Court.vue's initiateTactic():
+//  - "resolved": the effect was applied immediately (the turn is already ending)
+//  - "targeting": the card now awaits a target / stance / claim selection
+//  - "blocked": the card cannot legally be played right now (no valid target, etc.)
+//  - "lectern": the player entered "without notes" mode and must now pick a blind card
+export type InitiateResult = "resolved" | "targeting" | "blocked" | "lectern";
+
+interface LecternPlayRecord {
+  actor: TurnActor;
+  tacticName: string;
+  cardType: string;
+  targetName: string;
+  results: { justiceName: string; change: number }[];
+  round: number;
+  viaLectern?: boolean;
+}
+
+/* eslint-disable no-unused-vars -- base eslint rule incorrectly flags TS interface method parameter names */
+interface LecternDeps {
+  drawCard: () => Tactic | null;
+  removeFromPlaybook: (tactic: Tactic) => void;
+  shuffle: <T>(arr: T[]) => T[];
+  endPlayerTurn: () => void;
+  initiateTactic: (tactic: Tactic) => InitiateResult;
+  recordPlay: (play: LecternPlayRecord) => void;
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * "Go To The Lectern Without Notes" — the blind-gamble tactic.
+ *
+ * Playing the Lectern card flips the whole hand face-down, redraws, and reshuffles;
+ * the player then commits to one card sight-unseen. Whatever they play resolves at
+ * amplified power. This composable owns that flow end-to-end so Court.vue only has to
+ * wire it into selectTactic / initiateTactic / applyTactic.
+ */
+export function useCourtLectern(game: CourtGameState, deps: LecternDeps) {
+  const toast = useToast();
+
+  function playerToast(tacticName: string, feedback: string | null): void {
+    toast(
+      { component: TacticToast, props: { actor: "player", tacticName, results: [], feedback } },
+      {
+        position: POSITION.BOTTOM_RIGHT,
+        timeout: uiSettings.toastDuration === 0 ? false : uiSettings.toastDuration,
+        toastClassName: "court-toast court-toast--player",
+      },
+    );
+  }
+
+  // Play the Lectern card itself: burn it, redraw a replacement, then flip + shuffle the
+  // entire hand (shared Playbook AND claimed cards) so nothing can be tracked by position.
+  function enterLecternMode(lecternTactic: Tactic): void {
+    // Draw the replacement BEFORE discarding the Lectern card, so a near-empty deck can't
+    // reshuffle and immediately hand the Lectern card right back.
+    game.playbook = game.playbook.filter((t) => t.id !== lecternTactic.id);
+    const drawn = deps.drawCard();
+    if (drawn) game.playbook.push(drawn);
+    game.discardPile.push(lecternTactic);
+
+    game.playbook = deps.shuffle([...game.playbook]);
+    game.claimedCards = deps.shuffle([...game.claimedCards]);
+    game.selectedTacticId = null;
+
+    // Nothing to pick from (deck fully exhausted) — don't soft-lock the turn.
+    if (game.playbook.length === 0 && game.claimedCards.length === 0) {
+      deps.endPlayerTurn();
+      return;
+    }
+
+    game.lecternMode = true;
+    playerToast(lecternTactic.name, lecternTactic.feedback ?? null);
+  }
+
+  // Commit to a blind card (from the shared Playbook OR claimed cards) and route it onward.
+  function chooseLecternCard(tacticId: number): void {
+    const tactic = [...game.playbook, ...game.claimedCards].find((t) => t.id === tacticId);
+    if (!tactic) return;
+
+    game.lecternMode = false;
+    game.lecternBoostPending = true;
+    // Lock & hide: the committed card stays face-down and can't be deselected while it
+    // awaits a target. applyTactic / fizzle clears this once the play actually resolves.
+    game.lecternBlindTacticId = tactic.id;
+
+    const status = deps.initiateTactic(tactic);
+    if (status === "blocked") {
+      // The blind card has no legal play. Honor the gamble: it fizzles and the turn ends.
+      fizzleLecternCard(tactic);
+      return;
+    }
+
+    // Surprise Dibs: name the card so the follow-up claim step isn't baffling. The cards you
+    // claim stay face-down — you know the *action* (Dibs), not the cards you're grabbing.
+    if (status === "targeting" && tactic.effectType === "claim-two") {
+      playerToast(tactic.name, "Surprise — you blindly grabbed I Call Dibs! Pick 2 cards to claim. You still won't know what they are.");
+      return;
+    }
+
+    // Shield needs an allied (leaning > 0) target. With none on the bench the committed card
+    // would stall, so fizzle it instead.
+    if (status === "targeting" && tactic.effectType === "shield" && !game.bench.some((j) => (game.leanings[j.id] ?? 0) > 0)) {
+      game.selectedTacticId = null;
+      fizzleLecternCard(tactic);
+    }
+  }
+
+  function fizzleLecternCard(tactic: Tactic): void {
+    game.lecternBoostPending = false;
+    game.lecternBlindTacticId = null;
+
+    // Consume the dud so it leaves play like any other card.
+    const fromClaimed = game.claimedCards.some((t) => t.id === tactic.id);
+    if (fromClaimed) {
+      game.claimedCards = game.claimedCards.filter((t) => t.id !== tactic.id);
+      game.discardPile.push(tactic);
+      setTimeout(() => {
+        const drawn = deps.drawCard();
+        if (drawn) game.playbook.push(drawn);
+      }, 320);
+    } else {
+      deps.removeFromPlaybook(tactic);
+    }
+
+    deps.recordPlay({
+      actor: "player",
+      tacticName: tactic.name,
+      cardType: tactic.cardType,
+      targetName: "— (no play)",
+      results: [],
+      round: game.round,
+      viaLectern: true,
+    });
+
+    playerToast(tactic.name, "You confidently argued from notes you couldn't read. It went nowhere — but with conviction.");
+    deps.endPlayerTurn();
+  }
+
+  // Amplifies a just-resolved play's leaning swings (the "without notes" payoff). Operates on
+  // the outcome the resolver already produced, so it covers single-target, all-bench,
+  // multi-target, and knock-on results uniformly.
+  function applyLecternBoost(outcome: EffectOutcome): void {
+    const extra = LECTERN_BOOST - 1;
+    outcome.results.forEach((r) => {
+      if (!r.change) return;
+      const justice = game.bench.find((j: Justice) => j.name === r.justiceName);
+      if (!justice) return;
+      const bonus = Math.round(r.change * extra);
+      if (!bonus) return;
+      const old = game.leanings[justice.id] ?? 0;
+      const next = Math.max(-100, Math.min(100, old + bonus));
+      game.leanings[justice.id] = next;
+      r.change += next - old;
+      r.newLeaning = next;
+    });
+  }
+
+  return { enterLecternMode, chooseLecternCard, applyLecternBoost };
+}

--- a/src/views/court/ts/_useCourtLectern.ts
+++ b/src/views/court/ts/_useCourtLectern.ts
@@ -69,7 +69,19 @@ export function useCourtLectern(game: CourtGameState, deps: LecternDeps) {
 
     game.playbook = deps.shuffle([...game.playbook]);
     game.claimedCards = deps.shuffle([...game.claimedCards]);
+
+    // Clear any other in-progress selection so the blind pick starts from a clean slate.
+    // Without this, staging Swap Clerks (multi-target) or Reframe and THEN playing the
+    // Lectern card would leave the bench interpreting clicks for the old mode while the
+    // hand is face-down — a conflicting, soft-lockable UI state.
     game.selectedTacticId = null;
+    game.multiTargetMode = false;
+    game.multiTargetSelections = [];
+    game.multiTargetTacticId = null;
+    game.reframeStanceMode = false;
+    game.reframeStanceChoices = [];
+    game.reframeStanceTacticId = null;
+    game.reframeStanceSelection = null;
 
     // Nothing to pick from (deck fully exhausted) — don't soft-lock the turn.
     if (game.playbook.length === 0 && game.claimedCards.length === 0) {

--- a/src/views/court/ts/_useCourtStats.ts
+++ b/src/views/court/ts/_useCourtStats.ts
@@ -1,0 +1,161 @@
+import type { Ref } from "vue";
+import { useFirestore } from "vuefire";
+import type { CourtGameState, Tactic, TurnActor } from "./_types";
+import {
+  classifyJusticeVote,
+  computeTacticShiftMetrics,
+  createCourtStatsHelpers,
+  getOutcomeFromVerdict,
+  getTrackedStanceNamesForOutcome,
+  getWinningSide,
+  type CourtOutcome,
+  type JusticeVote,
+} from "./_statsHelpers";
+
+// The verdict computed only needs its won/tied flags here; keep the dependency narrow.
+type VerdictRef = Readonly<Ref<{ won: boolean; tied: boolean } | null>>;
+
+/* eslint-disable no-unused-vars -- base eslint rule incorrectly flags TS interface/param names */
+interface StatsDeps {
+  game: CourtGameState;
+  verdict: VerdictRef;
+  trialAttackedJustices: Set<string>;
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * All Firestore analytics for Supreme Court live here, behind a thin set of `track*`
+ * functions. Court.vue calls these at the relevant moments and never touches Firestore
+ * (or the raw stat-writers) directly. Every write is fire-and-forget and already
+ * error-swallowed inside createCourtStatsHelpers, so callers can `void` them freely.
+ */
+export function useCourtStats(deps: StatsDeps) {
+  const { game, verdict, trialAttackedJustices } = deps;
+  const courtStats = createCourtStatsHelpers(useFirestore());
+
+  function getCurrentOutcome(): CourtOutcome | null {
+    if (!verdict.value) return null;
+    return getOutcomeFromVerdict(verdict.value);
+  }
+
+  function buildVoteBuckets(): Record<string, JusticeVote> {
+    if (!game.playerSide) return {};
+    const playerSide = game.playerSide;
+    return Object.fromEntries(
+      game.bench.map((justice) => {
+        const leaning = game.leanings[justice.id] ?? 0;
+        return [justice.name, classifyJusticeVote(leaning, playerSide)];
+      }),
+    );
+  }
+
+  async function trackQuickplayStarted(): Promise<void> {
+    await courtStats.writeCourtAggregateStats({
+      gamesStarted: 1,
+      quickplaysStarted: 1,
+      lastQuickplayStarted: "__SERVER_TIMESTAMP__",
+      lastGameStarted: "__SERVER_TIMESTAMP__",
+    });
+  }
+
+  async function trackTacticPlay(tactic: Tactic, actor: TurnActor, results: Array<{ change: number }>): Promise<void> {
+    const metrics = computeTacticShiftMetrics(results);
+    await courtStats.writeTacticStats({
+      tacticName: tactic.name,
+      actor,
+      metrics: { ...metrics, netShift: Math.abs(metrics.netShift) },
+    });
+  }
+
+  async function trackTrialVerdictStats(options: { isQuickplay: boolean }): Promise<void> {
+    if (!game.currentCase || !game.playerSide) return;
+
+    const outcome = getCurrentOutcome();
+    if (!outcome) return;
+
+    const winningSide = getWinningSide(game.playerSide, outcome);
+    const aggregateOutcomeField = outcome === "won" ? "Won" : outcome === "lost" ? "Lost" : "Tied";
+    const benchJusticeNames = game.bench.map((justice) => justice.name);
+    const stanceNames = getTrackedStanceNamesForOutcome(game.currentCase, game.playerSide, outcome);
+    const voteByJusticeName = buildVoteBuckets();
+
+    const aggregateUpdates: Record<string, string | number> = {
+      totalCasesWon: outcome === "won" ? 1 : 0,
+      totalCasesLost: outcome === "lost" ? 1 : 0,
+      totalCasesTied: outcome === "tied" ? 1 : 0,
+    };
+
+    if (options.isQuickplay) {
+      aggregateUpdates.gamesFinished = 1;
+      aggregateUpdates.quickplaysFinished = 1;
+      aggregateUpdates[`quickplays${aggregateOutcomeField}`] = 1;
+      aggregateUpdates.lastQuickplayFinished = "__SERVER_TIMESTAMP__";
+      aggregateUpdates.lastGameFinished = "__SERVER_TIMESTAMP__";
+    }
+
+    await Promise.all([
+      courtStats.writeCourtAggregateStats(aggregateUpdates),
+      courtStats.writeCaseStats({ caseName: game.currentCase.name, outcome, winningSide }),
+      courtStats.writeJusticeStats({ benchJusticeNames, attackedJusticeNames: [...trialAttackedJustices] }),
+      courtStats.writeStanceStats({ stanceNames, outcome }),
+      courtStats.writeCaseJusticeVoteStats({
+        caseName: game.currentCase.name,
+        voteByJusticeName,
+        prosecutionName: game.currentCase.prosecution.name,
+        defenseName: game.currentCase.defendant.name,
+      }),
+    ]);
+  }
+
+  async function trackCampaignStarted(campaignName: string): Promise<void> {
+    await Promise.all([
+      courtStats.writeCourtAggregateStats({
+        gamesStarted: 1,
+        campaignsStarted: 1,
+        lastCampaignStarted: "__SERVER_TIMESTAMP__",
+        lastGameStarted: "__SERVER_TIMESTAMP__",
+      }),
+      courtStats.writeCampaignStats({ campaignName, event: "start" }),
+    ]);
+  }
+
+  async function trackCampaignCompleted(campaignName: string, won: boolean): Promise<void> {
+    await Promise.all([
+      courtStats.writeCourtAggregateStats({
+        gamesFinished: 1,
+        campaignsFinished: 1,
+        campaignsWon: won ? 1 : 0,
+        campaignsLost: won ? 0 : 1,
+        lastCampaignFinished: "__SERVER_TIMESTAMP__",
+        lastGameFinished: "__SERVER_TIMESTAMP__",
+      }),
+      courtStats.writeCampaignStats({ campaignName, event: won ? "win" : "loss" }),
+    ]);
+  }
+
+  // ── Campaign objective / reward writes (thin wrappers over the raw stat-writers) ──
+  function trackObjectiveChosen(objectiveName: string): void {
+    void courtStats.writeObjectiveStats({ objectiveName, chosen: true });
+  }
+  function trackObjectiveResult(objectiveName: string, won: boolean): void {
+    void courtStats.writeObjectiveStats({ objectiveName, succeeded: won, failed: !won });
+  }
+  function trackRewardActivated(rewardName: string): void {
+    void courtStats.writeRewardStats({ rewardName, activated: true });
+  }
+  function trackRewardChosen(rewardName: string): void {
+    void courtStats.writeRewardStats({ rewardName, chosen: true });
+  }
+
+  return {
+    trackQuickplayStarted,
+    trackTacticPlay,
+    trackTrialVerdictStats,
+    trackCampaignStarted,
+    trackCampaignCompleted,
+    trackObjectiveChosen,
+    trackObjectiveResult,
+    trackRewardActivated,
+    trackRewardChosen,
+  };
+}

--- a/src/views/court/ts/_useCourtTurns.ts
+++ b/src/views/court/ts/_useCourtTurns.ts
@@ -65,7 +65,7 @@ export function useCourtTurns(
 
     const browseTimer = setInterval(() => {
       elapsed += browseInterval;
-      const available = game.playbook.filter((t) => t.effectType !== "claim-two");
+      const available = game.playbook.filter((t) => t.effectType !== "claim-two" && t.effectType !== "lectern-without-notes");
       if (available.length) {
         const pick = available[Math.floor(Math.random() * available.length)];
         ui.opponentHighlightedCardId = pick.id;
@@ -80,7 +80,11 @@ export function useCourtTurns(
 
   function playOpponentTurn(): void {
     const available = game.playbook.filter(
-      (t) => t.effectType !== "claim-two" && t.effectType !== "suggest-retirement" && t.effectType !== "keep-crown",
+      (t) =>
+        t.effectType !== "claim-two" &&
+        t.effectType !== "suggest-retirement" &&
+        t.effectType !== "keep-crown" &&
+        t.effectType !== "lectern-without-notes",
     );
     if (!available.length) {
       endOpponentTurn();

--- a/src/views/court/ts/justices/_justicesCurrent.ts
+++ b/src/views/court/ts/justices/_justicesCurrent.ts
@@ -17,7 +17,6 @@ export const currentJustices: Justice[] = [
       logic: 8,
       charisma: 7,
       empathy: 5,
-
       susceptibility: 4,
       partyLoyalty: 6,
     },
@@ -71,7 +70,6 @@ export const currentJustices: Justice[] = [
       logic: 8,
       charisma: 3,
       empathy: 1,
-
       susceptibility: 3,
       partyLoyalty: 10,
     },
@@ -115,7 +113,6 @@ export const currentJustices: Justice[] = [
       logic: 7,
       charisma: 4,
       empathy: 2,
-
       susceptibility: 3,
       partyLoyalty: 10,
     },
@@ -169,7 +166,6 @@ export const currentJustices: Justice[] = [
       logic: 6,
       charisma: 8,
       empathy: 10,
-
       susceptibility: 4,
       partyLoyalty: 7,
     },
@@ -223,7 +219,6 @@ export const currentJustices: Justice[] = [
       logic: 9,
       charisma: 7,
       empathy: 5,
-
       susceptibility: 3,
       partyLoyalty: 7,
     },
@@ -320,7 +315,6 @@ export const currentJustices: Justice[] = [
       logic: 6,
       charisma: 5,
       empathy: 4,
-
       susceptibility: 5,
       partyLoyalty: 9,
     },
@@ -406,7 +400,7 @@ export const currentJustices: Justice[] = [
     name: "Ketanji Brown Jackson",
     image: "ketanji.webp",
     description:
-      "First Black woman on the Supreme Court. Knows what a biologist is. Sat through a Senate confirmation hearing where a senator asked her to define 'woman' and survived with her dignity intact.",
+      "First Black woman on the Supreme Court. Faced pointed questioning during Senate confirmation about her judicial philosophy and sentencing record — apparently being a former public defender is a character flaw now.",
     justiceType: "current",
     gender: "F",
     birthYear: 1970,

--- a/tests/court-unique-ids.spec.ts
+++ b/tests/court-unique-ids.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { campaignSetups } from "../src/views/court/ts/_campaigns";
+import { cases } from "../src/views/court/ts/_cases";
+import { objectives } from "../src/views/court/ts/_objectives";
+import { presidents } from "../src/views/court/ts/_presidents";
+import { rewardCards } from "../src/views/court/ts/_rewards";
+import { tactics } from "../src/views/court/ts/_tactics";
+import {
+  currentJustices,
+  historicalJustices,
+  fictionalJustices,
+  celebrityJustices,
+  warrenJustices,
+  lochnerJustices,
+} from "../src/views/court/ts/justices/index";
+
+type IdLike = string | number;
+
+/**
+ * Returns the list of ids that appear more than once, each paired with how
+ * many times it occurred. An empty array means every id is unique.
+ */
+function findDuplicateIds(items: { id: IdLike }[]): { id: IdLike; count: number }[] {
+  const counts = new Map<IdLike, number>();
+  for (const item of items) {
+    counts.set(item.id, (counts.get(item.id) ?? 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).map(([id, count]) => ({ id, count }));
+}
+
+describe("Court — unique ids", () => {
+  // Each dataset owns its own id space: a tactic with id 3 and a case with id 3
+  // is fine. These cases only fail if ids collide *within* a single dataset.
+  const datasets: { name: string; items: { id: IdLike }[] }[] = [
+    { name: "campaigns", items: campaignSetups },
+    { name: "cases", items: cases },
+    { name: "objectives", items: objectives },
+    { name: "presidents", items: presidents },
+    { name: "rewards", items: rewardCards },
+    { name: "tactics", items: tactics },
+  ];
+
+  for (const { name, items } of datasets) {
+    it(`${name} have no reused ids`, () => {
+      const duplicates = findDuplicateIds(items);
+      expect(duplicates, `Duplicate ${name} ids: ${JSON.stringify(duplicates)}`).toEqual([]);
+    });
+  }
+
+  // Justices are special: every justice — across every bench/era file — must
+  // have a globally unique id, since benches mix justices from different pools.
+  it("justices have no reused ids across all justice files", () => {
+    const allJustices = [
+      ...currentJustices,
+      ...historicalJustices,
+      ...fictionalJustices,
+      ...celebrityJustices,
+      ...warrenJustices,
+      ...lochnerJustices,
+    ];
+    const duplicates = findDuplicateIds(allJustices);
+    expect(duplicates, `Duplicate justice ids: ${JSON.stringify(duplicates)}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #282.

Adds a new chaotic tactic to Supreme Court: The Card Game — **Go To The Lectern Without Notes** — plus supporting cleanup.

💡 Idea credit: [u/velvet_umbrella](https://www.reddit.com/user/velvet_umbrella/).

## The card

Flip the whole hand face-down, draw a fresh card, reshuffle, and commit to a card **blind**. Whatever you play resolves at **1.6× power**. You can't see what you're playing until it lands, and you can't back out.

- Stays face-down through targeting (no deducing the unchosen cards).
- Blind pool spans the shared Playbook **and** claimed (Dibs) cards.
- Not claimable via Dibs; the AI opponent ignores it.
- Illegal blind picks (e.g. Shield with no allies) fizzle gracefully instead of soft-locking.
- Court Record badges blind plays with 🎤 **Without Notes**.

## Also in this PR

- **Invalid-target dimming** — restricted tactics (Shield, Betray Your Friend, Swap Clerks) now visually disable justices they can't target, instead of silently no-op'ing on click.
- **Refactor** — extracted `useCourtLectern` + `useCourtStats` composables; `Court.vue` drops from ~1180 → ~840 lines.
- **Test** — new `court-unique-ids.spec.ts` (no duplicate IDs across justices/cases/tactics/etc.), wired into the Court test group.
- **Docs** — `docs/court.md` rewritten as a strategy guide with real numbers.
- Bundles some in-progress current-court stat tweaks (`_campaigns`, `_tactics`, `_justicesCurrent`).

## Verification

- `vue-tsc` typecheck: 0 errors
- Full test suite: **108 passing**
- `Court.vue` passes lint (pre-existing lint errors elsewhere in the repo are untouched)
