### PR TITLE
#292 Isolate per-view SCSS to prevent cross-view CSS bleed

### DIFF
--- a/app/composables/useGameHead.ts
+++ b/app/composables/useGameHead.ts
@@ -42,6 +42,14 @@ interface GameHeadOptions {
   noZoomViewport?: boolean;
   /** Any extra meta a single page needs (e.g. site verification). */
   extraMeta?: HeadMeta[];
+  /**
+   * Per-route isolation class added to <html> and <body>. Lets a view scope its
+   * document-level rules (html/body base styles, teleported toast/tooltip
+   * overrides) as `html.<slug>` / `body.<slug>` so they can't bleed onto other
+   * routes. unhead removes the class when the page unmounts, so a stale (dev
+   * HMR-persisted) stylesheet from the previous route matches nothing.
+   */
+  bodyClass?: string;
 }
 
 export function useGameHead(options: GameHeadOptions) {
@@ -59,6 +67,7 @@ export function useGameHead(options: GameHeadOptions) {
     themeColor,
     noZoomViewport = false,
     extraMeta = [],
+    bodyClass,
   } = options;
 
   const url = `https://kinda.fun${path}`;
@@ -102,6 +111,7 @@ export function useGameHead(options: GameHeadOptions) {
     title,
     link,
     meta,
+    ...(bodyClass ? { htmlAttrs: { class: bodyClass }, bodyAttrs: { class: bodyClass } } : {}),
     ...(jsonLd ? { script: [{ type: "application/ld+json", innerHTML: JSON.stringify(jsonLd) }] } : {}),
   });
 }

--- a/app/composables/useGameHead.ts
+++ b/app/composables/useGameHead.ts
@@ -43,13 +43,13 @@ interface GameHeadOptions {
   /** Any extra meta a single page needs (e.g. site verification). */
   extraMeta?: HeadMeta[];
   /**
-   * Per-route isolation class added to <html> and <body>. Lets a view scope its
-   * document-level rules (html/body base styles, teleported toast/tooltip
+   * Per-route isolation class added to BOTH <html> and <body>. Lets a view scope
+   * its document-level rules (html/body base styles, teleported toast/tooltip
    * overrides) as `html.<slug>` / `body.<slug>` so they can't bleed onto other
    * routes. unhead removes the class when the page unmounts, so a stale (dev
    * HMR-persisted) stylesheet from the previous route matches nothing.
    */
-  bodyClass?: string;
+  routeClass?: string;
 }
 
 export function useGameHead(options: GameHeadOptions) {
@@ -67,7 +67,7 @@ export function useGameHead(options: GameHeadOptions) {
     themeColor,
     noZoomViewport = false,
     extraMeta = [],
-    bodyClass,
+    routeClass,
   } = options;
 
   const url = `https://kinda.fun${path}`;
@@ -111,7 +111,7 @@ export function useGameHead(options: GameHeadOptions) {
     title,
     link,
     meta,
-    ...(bodyClass ? { htmlAttrs: { class: bodyClass }, bodyAttrs: { class: bodyClass } } : {}),
+    ...(routeClass ? { htmlAttrs: { class: routeClass }, bodyAttrs: { class: routeClass } } : {}),
     ...(jsonLd ? { script: [{ type: "application/ld+json", innerHTML: JSON.stringify(jsonLd) }] } : {}),
   });
 }

--- a/app/pages/cameo.vue
+++ b/app/pages/cameo.vue
@@ -64,6 +64,7 @@
     path: "/cameo",
     ogImage: "https://kinda.fun/img/og-famous.png",
     themeColor: "#3b1666",
+    bodyClass: "cameo",
     fonts: ["https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700&family=Open+Sans:wght@400;700&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/famous/apple-touch-icon.png", key: "fav-apple" },
@@ -77,5 +78,7 @@
 </script>
 
 <template>
-  <Cameo />
+  <div class="cameo-view">
+    <Cameo />
+  </div>
 </template>

--- a/app/pages/cameo.vue
+++ b/app/pages/cameo.vue
@@ -64,7 +64,7 @@
     path: "/cameo",
     ogImage: "https://kinda.fun/img/og-famous.png",
     themeColor: "#3b1666",
-    bodyClass: "cameo",
+    routeClass: "cameo",
     fonts: ["https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700&family=Open+Sans:wght@400;700&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/famous/apple-touch-icon.png", key: "fav-apple" },

--- a/app/pages/court.vue
+++ b/app/pages/court.vue
@@ -56,7 +56,7 @@
     description: "The single player game about meddling with the law. Because if justice isn't fair, at least it should be fun!",
     path: "/court",
     ogImage: "https://kinda.fun/img/og-court.png",
-    bodyClass: "court",
+    routeClass: "court",
     // Match the legacy per-page viewport: disable zoom so double-tapping cards
     // doesn't trigger mobile zoom mid-game.
     noZoomViewport: true,

--- a/app/pages/court.vue
+++ b/app/pages/court.vue
@@ -56,6 +56,7 @@
     description: "The single player game about meddling with the law. Because if justice isn't fair, at least it should be fun!",
     path: "/court",
     ogImage: "https://kinda.fun/img/og-court.png",
+    bodyClass: "court",
     // Match the legacy per-page viewport: disable zoom so double-tapping cards
     // doesn't trigger mobile zoom mid-game.
     noZoomViewport: true,
@@ -65,5 +66,7 @@
 </script>
 
 <template>
-  <Court />
+  <div class="court-view">
+    <Court />
+  </div>
 </template>

--- a/app/pages/guillotine.vue
+++ b/app/pages/guillotine.vue
@@ -48,7 +48,7 @@
     description: "Generating wealth with a guillotine.",
     path: "/guillotine",
     ogImage: "https://kinda.fun/img/og-guillotine.jpg",
-    bodyClass: "guillotine",
+    routeClass: "guillotine",
     fonts: [
       "https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@300..700&display=swap",
       // $monospaced (counters, title/share screens, stats) uses JetBrains Mono.

--- a/app/pages/guillotine.vue
+++ b/app/pages/guillotine.vue
@@ -48,6 +48,7 @@
     description: "Generating wealth with a guillotine.",
     path: "/guillotine",
     ogImage: "https://kinda.fun/img/og-guillotine.jpg",
+    bodyClass: "guillotine",
     fonts: [
       "https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@300..700&display=swap",
       // $monospaced (counters, title/share screens, stats) uses JetBrains Mono.
@@ -58,5 +59,7 @@
 </script>
 
 <template>
-  <Guillotine />
+  <div class="guillotine-view">
+    <Guillotine />
+  </div>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -49,6 +49,7 @@
     path: "",
     ogImage: "https://kinda.fun/img/og-wide.png",
     themeColor: "#e5e828",
+    bodyClass: "home",
     fonts: ["https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"],
     extraMeta: [{ name: "msvalidate.01", content: "D3327FD7610C2D05D7D605EBCA288944" }],
     jsonLd,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -49,7 +49,7 @@
     path: "",
     ogImage: "https://kinda.fun/img/og-wide.png",
     themeColor: "#e5e828",
-    bodyClass: "home",
+    routeClass: "home",
     fonts: ["https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lora:ital,wght@0,400..700;1,400..700&display=swap"],
     extraMeta: [{ name: "msvalidate.01", content: "D3327FD7610C2D05D7D605EBCA288944" }],
     jsonLd,

--- a/app/pages/invalid.vue
+++ b/app/pages/invalid.vue
@@ -59,6 +59,7 @@
     description: "A trivia game of unnecessary suffering.",
     path: "/invalid",
     ogImage: "https://kinda.fun/img/og-invalid.png",
+    bodyClass: "invalid",
     fonts: ["https://fonts.googleapis.com/css2?family=Big+Shoulders:opsz,wght@10..72,100..900&family=Lora:ital,wght@0,400..700;1,400..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/invalid/apple-touch-icon.png", key: "fav-apple" },
@@ -71,5 +72,7 @@
 </script>
 
 <template>
-  <Invalid />
+  <div class="invalid-view">
+    <Invalid />
+  </div>
 </template>

--- a/app/pages/invalid.vue
+++ b/app/pages/invalid.vue
@@ -59,7 +59,7 @@
     description: "A trivia game of unnecessary suffering.",
     path: "/invalid",
     ogImage: "https://kinda.fun/img/og-invalid.png",
-    bodyClass: "invalid",
+    routeClass: "invalid",
     fonts: ["https://fonts.googleapis.com/css2?family=Big+Shoulders:opsz,wght@10..72,100..900&family=Lora:ital,wght@0,400..700;1,400..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/invalid/apple-touch-icon.png", key: "fav-apple" },

--- a/app/pages/meeting.vue
+++ b/app/pages/meeting.vue
@@ -52,7 +52,7 @@
     description: "So now you have a reason to pay attention.",
     path: "/meeting",
     ogImage: "https://kinda.fun/img/og-meeting.png",
-    bodyClass: "meeting",
+    routeClass: "meeting",
     fonts: ["https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Vollkorn:ital,wght@0,400..900;1,400..900&display=swap"],
     jsonLd,
   });

--- a/app/pages/meeting.vue
+++ b/app/pages/meeting.vue
@@ -52,11 +52,14 @@
     description: "So now you have a reason to pay attention.",
     path: "/meeting",
     ogImage: "https://kinda.fun/img/og-meeting.png",
+    bodyClass: "meeting",
     fonts: ["https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Vollkorn:ital,wght@0,400..900;1,400..900&display=swap"],
     jsonLd,
   });
 </script>
 
 <template>
-  <Meeting />
+  <div class="meeting-view">
+    <Meeting />
+  </div>
 </template>

--- a/app/pages/megachurch.vue
+++ b/app/pages/megachurch.vue
@@ -54,7 +54,7 @@
     description: "Turn their faith into your fortune, one scam at a time.",
     path: "/megachurch",
     ogImage: "https://kinda.fun/img/og-megachurch.jpg",
-    bodyClass: "megachurch",
+    routeClass: "megachurch",
     fonts: ["https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,100..900;1,100..900&family=Commissioner:wght@100..900&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/megachurch/apple-touch-icon.png", key: "fav-apple" },

--- a/app/pages/megachurch.vue
+++ b/app/pages/megachurch.vue
@@ -54,6 +54,7 @@
     description: "Turn their faith into your fortune, one scam at a time.",
     path: "/megachurch",
     ogImage: "https://kinda.fun/img/og-megachurch.jpg",
+    bodyClass: "megachurch",
     fonts: ["https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,100..900;1,100..900&family=Commissioner:wght@100..900&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/megachurch/apple-touch-icon.png", key: "fav-apple" },
@@ -66,5 +67,7 @@
 </script>
 
 <template>
-  <Megachurch />
+  <div class="megachurch-view">
+    <Megachurch />
+  </div>
 </template>

--- a/app/pages/pretend.vue
+++ b/app/pages/pretend.vue
@@ -55,7 +55,7 @@
     description: "You are at a party of celebrity impersonators...",
     path: "/pretend",
     ogImage: "https://kinda.fun/img/og-pretend.png",
-    bodyClass: "pretend",
+    routeClass: "pretend",
     fonts: ["https://fonts.googleapis.com/css?family=Limelight|Merriweather:400,400i,900"],
     jsonLd,
   });

--- a/app/pages/pretend.vue
+++ b/app/pages/pretend.vue
@@ -55,11 +55,14 @@
     description: "You are at a party of celebrity impersonators...",
     path: "/pretend",
     ogImage: "https://kinda.fun/img/og-pretend.png",
+    bodyClass: "pretend",
     fonts: ["https://fonts.googleapis.com/css?family=Limelight|Merriweather:400,400i,900"],
     jsonLd,
   });
 </script>
 
 <template>
-  <Pretend />
+  <div class="pretend-view">
+    <Pretend />
+  </div>
 </template>

--- a/app/pages/sisyphus.vue
+++ b/app/pages/sisyphus.vue
@@ -56,7 +56,7 @@
     // Match the legacy per-page viewport: disable zoom so rapid tapping in this
     // clicker doesn't trigger mobile double-tap zoom.
     noZoomViewport: true,
-    bodyClass: "sisyphus",
+    routeClass: "sisyphus",
     fonts: ["https://fonts.googleapis.com/css?family=Crimson+Text:400,400i,700|Poppins:400,400i,700"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/sisyphus/apple-touch-icon.png", key: "fav-apple" },

--- a/app/pages/sisyphus.vue
+++ b/app/pages/sisyphus.vue
@@ -56,6 +56,7 @@
     // Match the legacy per-page viewport: disable zoom so rapid tapping in this
     // clicker doesn't trigger mobile double-tap zoom.
     noZoomViewport: true,
+    bodyClass: "sisyphus",
     fonts: ["https://fonts.googleapis.com/css?family=Crimson+Text:400,400i,700|Poppins:400,400i,700"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/sisyphus/apple-touch-icon.png", key: "fav-apple" },
@@ -70,5 +71,7 @@
 </script>
 
 <template>
-  <Sisyphus />
+  <div class="sisyphus-view">
+    <Sisyphus />
+  </div>
 </template>

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -11,10 +11,13 @@
     description: "Let's see what people are playing.",
     path: "/stats",
     themeColor: "#e5e828",
+    bodyClass: "stats",
     fonts: ["https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Lora:ital,wght@0,400..700;1,400..700&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"],
   });
 </script>
 
 <template>
-  <Stats />
+  <div class="stats-view">
+    <Stats />
+  </div>
 </template>

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -11,7 +11,7 @@
     description: "Let's see what people are playing.",
     path: "/stats",
     themeColor: "#e5e828",
-    bodyClass: "stats",
+    routeClass: "stats",
     fonts: ["https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&family=Lora:ital,wght@0,400..700;1,400..700&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap"],
   });
 </script>

--- a/app/pages/wrongest.vue
+++ b/app/pages/wrongest.vue
@@ -58,6 +58,7 @@
     path: "/wrongest",
     ogImage: "https://kinda.fun/img/og-wrongest.png",
     themeColor: "#ef507a",
+    bodyClass: "wrongest",
     fonts: ["https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;600&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/wrongest/apple-touch-icon.png", key: "fav-apple" },
@@ -70,5 +71,7 @@
 </script>
 
 <template>
-  <Wrongest />
+  <div class="wrongest-view">
+    <Wrongest />
+  </div>
 </template>

--- a/app/pages/wrongest.vue
+++ b/app/pages/wrongest.vue
@@ -58,7 +58,7 @@
     path: "/wrongest",
     ogImage: "https://kinda.fun/img/og-wrongest.png",
     themeColor: "#ef507a",
-    bodyClass: "wrongest",
+    routeClass: "wrongest",
     fonts: ["https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;600&display=swap"],
     favicons: [
       { rel: "apple-touch-icon", sizes: "180x180", href: "/img/wrongest/apple-touch-icon.png", key: "fav-apple" },

--- a/src/shared/scss/globals/_index.scss
+++ b/src/shared/scss/globals/_index.scss
@@ -3,14 +3,10 @@
 // one namespace. `reset` is intentionally NOT forwarded here — it emits CSS rather
 // than members, so entry files `@use` it directly, once.
 //
-// KNOWN (pre-existing, dev-only): view stylesheets are global/unscoped and share
-// generic selectors (`main.title-screen`, bare `body`/`main`, etc.). In production
-// this is harmless — games launch via full-page `<a href>` loads, so each page only
-// ever contains its own CSS. In `nuxi dev`, Vite/HMR can keep a previously-visited
-// view's styles injected when you client-side navigate back to home, so home may
-// briefly render with a game's background/colors. A hard refresh clears it. A real
-// fix (scoping views) is deferred: it would break teleported toasts/tooltips and
-// the intentionally-global animate.css / vue-toastification bundles.
+// View CSS is isolated per route: each entry (e.g. cameo/Cameo.scss) nests its
+// rules under a `.<slug>-view` wrapper and scopes document-level rules as
+// `html.<slug>`/`body.<slug>`. Only this reset and 3rd-party libraries stay
+// global. Keep `@keyframes` names view-unique — they share one global namespace.
 @forward "variables";
 @forward "mixins";
 @forward "extends";

--- a/src/views/cameo/Cameo.pug
+++ b/src/views/cameo/Cameo.pug
@@ -8,4 +8,4 @@ include pug/_email
 
 include pug/_hud
 
-include pug/_game-over  
+include pug/_game-over

--- a/src/views/cameo/Cameo.scss
+++ b/src/views/cameo/Cameo.scss
@@ -1,20 +1,30 @@
-// Shared reset emits CSS (not members), so @use it directly, once.
-@use "@/shared/scss/globals/reset";
+// Per-route CSS isolation (#292). Three buckets:
+//   1. GLOBAL   — shared reset + 3rd-party libs. Identical across views, so
+//                 harmless if a stale (dev HMR) copy lingers after navigation.
+//   2. DOCUMENT — html/body base + teleported toast targets. Route-scoped via
+//                 the `cameo` class useGameHead adds to <html>/<body>.
+//   3. VIEW     — everything inside the .cameo-view wrapper, nested under it
+//                 with meta.load-css so no selector can match another route.
+@use "sass:meta";
 
-// LIBRARIES (if any)
+// 1. GLOBAL
+@use "@/shared/scss/globals/reset";
 @use "@/shared/scss/libraries/animate";
 @use "@/shared/scss/libraries/vue_toastification";
 
-// SITE SPECIFIC
-@use "scss/defaults";
-@use "scss/hud";
-@use "scss/toast";
+// 2. DOCUMENT
+@use "scss/defaults"; // [v-cloak] (global) + html.cameo base
 
-// SCREENS
-@use "scss/title-screen";
-@use "scss/sort";
-@use "scss/email";
-@use "scss/final-round";
-@use "scss/game-over";
+body.cameo {
+  @include meta.load-css("scss/toast");
+}
 
-//@use "scss/mobile";
+// 3. VIEW
+.cameo-view {
+  @include meta.load-css("scss/hud");
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/sort");
+  @include meta.load-css("scss/email");
+  @include meta.load-css("scss/final-round");
+  @include meta.load-css("scss/game-over");
+}

--- a/src/views/cameo/scss/_defaults.scss
+++ b/src/views/cameo/scss/_defaults.scss
@@ -3,7 +3,7 @@
 [v-cloak] {
   display: none !important;
 }
-html {
+html.cameo {
   font-size: 15px;
   font-family: $font-family;
   background: #111;

--- a/src/views/cameo/scss/_sort.scss
+++ b/src/views/cameo/scss/_sort.scss
@@ -272,20 +272,6 @@ main.sort-three {
   }
 }
 
-.v-toast.v-toast--bottom {
-  padding-bottom: 3.2em;
-}
-.v-toast__text {
-  h2 {
-    font-family: $displayFont;
-    font-size: 38px;
-  }
-  h4 {
-    font-family: $displayFont;
-    font-size: 19px;
-  }
-}
-
 @media (max-width: 810px) {
   .three-to-compare {
     gap: 4px;

--- a/src/views/cameo/scss/_toast.scss
+++ b/src/views/cameo/scss/_toast.scss
@@ -1,3 +1,19 @@
+@use "index" as *;
+
+.v-toast.v-toast--bottom {
+  padding-bottom: 3.2em;
+}
+.v-toast__text {
+  h2 {
+    font-family: $displayFont;
+    font-size: 38px;
+  }
+  h4 {
+    font-family: $displayFont;
+    font-size: 19px;
+  }
+}
+
 @media only screen and (max-width: 600px) {
   .Vue-Toastification__container.bottom-left,
   .Vue-Toastification__container.bottom-right,

--- a/src/views/court/Court.scss
+++ b/src/views/court/Court.scss
@@ -1,36 +1,54 @@
-// ─── Base ────────────────────────────────────────────────────
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset + 3rd-party libs (tippy, toast). Identical
+//                 across views. @keyframes embedded in the view partials hoist
+//                 to the top level regardless of nesting, so they effectively
+//                 stay global too — no need to pull them out.
+//   2. DOCUMENT — teleported toast/tippy targets, route-scoped under body.court
+//                 (the `court` class useGameHead adds). Court has no
+//                 html/body/:root rules, so there is no _document.scss.
+//   3. VIEW     — everything inside .court-view, nested via meta.load-css so no
+//                 selector can match another route. Original @use order kept.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
-
-// ─── Components ──────────────────────────────────────────────
-@use "./scss/components/tippy";
-@use "./scss/components/buttons";
-@use "./scss/components/bench";
-@use "./scss/components/layout";
-@use "./scss/components/campaign-banner";
-@use "./scss/components/cheats";
-@use "./scss/components/lemon-toast";
-
-// ─── Screens ─────────────────────────────────────────────────
-@use "./scss/screens/court-select";
-@use "./scss/screens/playing";
-@use "./scss/screens/report";
-@use "./scss/screens/verdict";
-@use "./scss/screens/setup";
-@use "./scss/screens/title";
-@use "./scss/screens/campaign-select";
-@use "./scss/screens/objective-draw";
-@use "./scss/screens/receive-reward-and-activate-bonus";
-@use "./scss/screens/recess";
-@use "./scss/screens/game-over";
-
-// ─── Modals ──────────────────────────────────────────────────
-@use "./scss/modals/court-record";
-@use "./scss/modals/justice-detail";
-@use "./scss/modals/president-detail";
-
-// ─── Shame ───────────────────────────────────────────────────
-@use "./scss/todo/shame";
-
-// ─── Libraries (CSS-emitting, kept last so their CSS lands last) ──
 @use "@/shared/scss/libraries/tippy" as tippy-lib;
 @use "@/shared/scss/libraries/vue_toastification";
+
+// 2. DOCUMENT
+body.court {
+  // Teleported targets render into <body>, outside .court-view.
+  @include meta.load-css("scss/components/lemon-toast"); // .Vue-Toastification__*
+  @include meta.load-css("scss/components/tippy"); // .tippy-content
+}
+
+// 3. VIEW
+.court-view {
+  // ─── Components ──────────────────────────────────────────────
+  @include meta.load-css("scss/components/buttons");
+  @include meta.load-css("scss/components/bench");
+  @include meta.load-css("scss/components/layout");
+  @include meta.load-css("scss/components/campaign-banner");
+  @include meta.load-css("scss/components/cheats");
+
+  // ─── Screens ─────────────────────────────────────────────────
+  @include meta.load-css("scss/screens/court-select");
+  @include meta.load-css("scss/screens/playing");
+  @include meta.load-css("scss/screens/report");
+  @include meta.load-css("scss/screens/verdict");
+  @include meta.load-css("scss/screens/setup");
+  @include meta.load-css("scss/screens/title");
+  @include meta.load-css("scss/screens/campaign-select");
+  @include meta.load-css("scss/screens/objective-draw");
+  @include meta.load-css("scss/screens/receive-reward-and-activate-bonus");
+  @include meta.load-css("scss/screens/recess");
+  @include meta.load-css("scss/screens/game-over");
+
+  // ─── Modals ──────────────────────────────────────────────────
+  @include meta.load-css("scss/modals/court-record");
+  @include meta.load-css("scss/modals/justice-detail");
+  @include meta.load-css("scss/modals/president-detail");
+
+  // ─── Shame ───────────────────────────────────────────────────
+  @include meta.load-css("scss/todo/shame");
+}

--- a/src/views/guillotine/Guillotine.scss
+++ b/src/views/guillotine/Guillotine.scss
@@ -1,41 +1,54 @@
-// General structure adopted from Kitty Giraudel
-// https://sass-guidelin.es/#architecture
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — guillotine's own reset + the animate.css library. Identical/
+//                 harmless across views (and @keyframes hoist to the top level
+//                 regardless of nesting, so animate.css must stay unwrapped).
+//   2. DOCUMENT — html/body base + the teleported pnotify toast target, route-
+//                 scoped as html.guillotine / body.guillotine (useGameHead
+//                 bodyClass: "guillotine").
+//   3. VIEW     — everything inside the .guillotine-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
 //
-// ABSTRACTS (variables, mixins, %extends, z-index) are member-only and now live
-// in scss/_index.scss; every partial `@use`s that index directly, so the entry
-// only needs to pull in the CSS-emitting partials, in cascade order.
+// General structure adopted from Kitty Giraudel — https://sass-guidelin.es/#architecture
+// ABSTRACTS (variables, mixins, %extends, z-index) are member-only and live in
+// scss/_index.scss; every partial `@use`s that index directly.
+@use "sass:meta";
 
-// BASE is for things like global site styles and typography.
+// 1. GLOBAL
 @use "scss/base/reset";
-@use "scss/base/defaults";
-@use "scss/base/animations";
-
-// LIBRARIES is for third party Scss
 @use "scss/libraries/animate";
 
-// COMPONENTS is for stuff like buttons, cards, callouts, toasts, etc... Essentially - reusable rectangles.
-@use "scss/components/billionaire";
-@use "scss/components/toast";
+// 2. DOCUMENT
+@use "scss/base/document"; // [v-cloak] (global) + html.guillotine / body.guillotine base
 
-// LAYOUT is for stuff like a grid system, topnav, footer, etc.
-@use "scss/layout/desktop";
-@use "scss/layout/footer";
+body.guillotine {
+  // Teleported pnotify toast target renders into <body>, outside .guillotine-view.
+  @include meta.load-css("scss/components/toast");
+}
 
-// SECTIONS is a stripe (like a hero section) - like a component, but bigger.
-@use "scss/sections/share-screen";
+// 3. VIEW
+.guillotine-view {
+  // BASE
+  @include meta.load-css("scss/base/defaults");
+  @include meta.load-css("scss/base/animations");
 
-@use "scss/sections/title-screen";
+  // COMPONENTS — reusable rectangles (buttons, cards, callouts, etc.)
+  @include meta.load-css("scss/components/billionaire");
 
-@use "scss/sections/choices";
-@use "scss/sections/gallows";
-@use "scss/sections/graves";
+  // LAYOUT — grid system, topnav, footer, etc.
+  @include meta.load-css("scss/layout/desktop");
+  @include meta.load-css("scss/layout/footer");
 
-@use "scss/sections/footer/stats";
-@use "scss/sections/footer/citations";
-@use "scss/sections/footer/final-links";
-@use "scss/sections/footer/by-lemon";
+  // SECTIONS — a stripe (like a hero section); a component, but bigger.
+  @include meta.load-css("scss/sections/share-screen");
+  @include meta.load-css("scss/sections/title-screen");
+  @include meta.load-css("scss/sections/choices");
+  @include meta.load-css("scss/sections/gallows");
+  @include meta.load-css("scss/sections/graves");
+  @include meta.load-css("scss/sections/footer/stats");
+  @include meta.load-css("scss/sections/footer/citations");
+  @include meta.load-css("scss/sections/footer/final-links");
+  @include meta.load-css("scss/sections/footer/by-lemon");
 
-// PAGES is for any specific page template
-
-// FINALLY, we should have a place for things we still need to get to...
-@use "scss/todo/shame";
+  // FINALLY, a place for things we still need to get to...
+  @include meta.load-css("scss/todo/shame");
+}

--- a/src/views/guillotine/scss/base/_defaults.scss
+++ b/src/views/guillotine/scss/base/_defaults.scss
@@ -1,20 +1,5 @@
 @use "../index" as *;
 
-[v-cloak] {
-  display: none !important;
-}
-
-html {
-  font-size: 100%;
-}
-body {
-  background: $body;
-  color: $copy;
-  font-family: $font-family;
-  font-weight: $medium;
-  line-height: 1.75;
-}
-
 h1,
 h2,
 h3,

--- a/src/views/guillotine/scss/base/_document.scss
+++ b/src/views/guillotine/scss/base/_document.scss
@@ -1,0 +1,21 @@
+@use "../index" as *;
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none !important;
+}
+
+// Document-level rules for guillotine. Route-scoped via the `guillotine` class
+// useGameHead adds to <html>/<body> (#292), so they can't bleed onto other
+// routes (and a stale dev-HMR copy can't paint another view). The html/body
+// typographic rules used to live in _defaults.scss.
+html.guillotine {
+  font-size: 100%;
+}
+body.guillotine {
+  background: $body;
+  color: $copy;
+  font-family: $font-family;
+  font-weight: $medium;
+  line-height: 1.75;
+}

--- a/src/views/home/Home.pug
+++ b/src/views/home/Home.pug
@@ -1,39 +1,40 @@
-main.title-screen
+.home-view
+  main.title-screen
 
-  .top
-    h1 So, here's some stuff that's kinda fun...
+    .top
+      h1 So, here's some stuff that's kinda fun...
 
-  transition-group(name="list" tag="div" id="GameGrid" class="game-grid")
+    transition-group(name="list" tag="div" id="GameGrid" class="game-grid")
 
-      .thing(
-        v-for="(thing, thingId) in computedThingsList"
-        :class="{ active: currentThing.slug === thing.slug,  inactive: (currentThing.slug && currentThing.slug !== thing.slug) }"
-        :key="thing.slug")
-        button(@click="selectGame(thing.slug)" :title="thing.name")
-          template(v-if="thing.logo")
-            img.logo(:src="`/svg/games/${thing.logo}`" :alt="thing.name")
+        .thing(
+          v-for="(thing, thingId) in computedThingsList"
+          :class="{ active: currentThing.slug === thing.slug,  inactive: (currentThing.slug && currentThing.slug !== thing.slug) }"
+          :key="thing.slug")
+          button(@click="selectGame(thing.slug)" :title="thing.name")
+            template(v-if="thing.logo")
+              img.logo(:src="`/svg/games/${thing.logo}`" :alt="thing.name")
 
-  .bottom
-    .info-holder
-      transition(name="boing")
-        .info(v-cloak v-if="currentThing && currentThing.name")
-          button.close(@click="selectGame('')") X
-          .top-bar
-            h2.game-name {{currentThing.name}}
-          .content
-            template(v-if="currentThing.slogan")
-              h3.slogan {{currentThing.slogan}}
-            template(v-if="currentThing.description")
-              .description(v-html="currentThing.description")
-            template(v-if="currentThing.url")
-              .button-holder
-                a.play-game.button(:href="currentThing.url") {{ computedButtonText }}
-    
-    .filter-options
-      label Filter To:
-      button.show-all(@click="setFilterTo('all')" :class="{ 'active': !ui.currentFilter }") 
-        span.text Show All
-      template(v-for="tag in computedTags" :key="tag.text")
-        button(@click="setFilterTo(tag.text)" :class="{ active: (ui.currentFilter == tag.text) }")
-          span.text {{tag.text}}
-          span.count {{tag.count}} 
+    .bottom
+      .info-holder
+        transition(name="boing")
+          .info(v-cloak v-if="currentThing && currentThing.name")
+            button.close(@click="selectGame('')") X
+            .top-bar
+              h2.game-name {{currentThing.name}}
+            .content
+              template(v-if="currentThing.slogan")
+                h3.slogan {{currentThing.slogan}}
+              template(v-if="currentThing.description")
+                .description(v-html="currentThing.description")
+              template(v-if="currentThing.url")
+                .button-holder
+                  a.play-game.button(:href="currentThing.url") {{ computedButtonText }}
+
+      .filter-options
+        label Filter To:
+        button.show-all(@click="setFilterTo('all')" :class="{ 'active': !ui.currentFilter }")
+          span.text Show All
+        template(v-for="tag in computedTags" :key="tag.text")
+          button(@click="setFilterTo(tag.text)" :class="{ active: (ui.currentFilter == tag.text) }")
+            span.text {{tag.text}}
+            span.count {{tag.count}}

--- a/src/views/home/Home.scss
+++ b/src/views/home/Home.scss
@@ -1,7 +1,21 @@
-// Shared reset emits CSS (not members), so @use it directly, once.
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset (identical across views).
+//   2. DOCUMENT — html/body base + teleported .v-toast, route-scoped as
+//                 html.home / body.home (useGameHead bodyClass: "home").
+//   3. VIEW     — everything inside the .home-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
 
-@use "scss/default";
-@use "scss/transitions";
-@use "scss/title-screen";
-@use "scss/testing";
+// 2. DOCUMENT
+@use "scss/document";
+
+// 3. VIEW
+.home-view {
+  @include meta.load-css("scss/default");
+  @include meta.load-css("scss/transitions");
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/testing");
+}

--- a/src/views/home/scss/_default.scss
+++ b/src/views/home/scss/_default.scss
@@ -1,15 +1,3 @@
-html {
-  background: radial-gradient(#353535, #161616);
-  color: #eee;
-  background-attachment: fixed;
-}
 p {
   margin-bottom: 1em;
-}
-[v-cloak] {
-  display: none;
-}
-
-.v-toast {
-  font-family: "Lora", serif;
 }

--- a/src/views/home/scss/_document.scss
+++ b/src/views/home/scss/_document.scss
@@ -1,0 +1,25 @@
+@use "index" as *;
+
+// Document-level rules for home. Route-scoped via the `home` class useGameHead
+// adds to <html>/<body> (#292), so they can't bleed onto other routes and a
+// stale (dev HMR) copy from another view can't paint home.
+html.home {
+  background: radial-gradient(#353535, #161616);
+  color: #eee;
+  background-attachment: fixed;
+  width: 100dvw;
+}
+body.home {
+  overflow-x: hidden;
+  width: 100dvw;
+
+  // Teleported toast target lives in <body>, outside .home-view.
+  .v-toast {
+    font-family: "Lora", serif;
+  }
+}
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none;
+}

--- a/src/views/home/scss/_title-screen.scss
+++ b/src/views/home/scss/_title-screen.scss
@@ -1,12 +1,5 @@
 @use "index" as *;
 
-html {
-  width: 100dvw;
-}
-body {
-  overflow-x: hidden;
-  width: 100dvw;
-}
 .title-screen {
   min-height: 99.999dvh;
   display: grid;

--- a/src/views/invalid/Invalid.scss
+++ b/src/views/invalid/Invalid.scss
@@ -1,29 +1,47 @@
-// Shared reset emits CSS (not members), so @use it directly, once.
-@use "@/shared/scss/globals/reset";
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset + toast lib. Identical across views, so harmless
+//                 if a stale (dev HMR) copy lingers after navigation. @keyframes
+//                 inside view partials hoist to the root regardless of nesting.
+//   2. DOCUMENT — [v-cloak] + body base + teleported toast targets, route-scoped
+//                 via the `invalid` class useGameHead adds to <html>/<body>.
+//   3. VIEW     — everything inside .invalid-view, nested via meta.load-css so no
+//                 selector can match another route.
+@use "sass:meta";
 
-// LIBRARIES (if any)
+// 1. GLOBAL
+@use "@/shared/scss/globals/reset";
 @use "@/shared/scss/libraries/vue_toastification";
 
-// SITE SPECIFIC
-@use "scss/default";
-@use "scss/scores";
+// 2. DOCUMENT
+@use "scss/document"; // [v-cloak] (global) + body.invalid base + .v-toast
 
-// SCREENS
-@use "scss/pregame";
-@use "scss/title-screen";
-@use "scss/admin";
-@use "scss/employee";
-@use "scss/crash";
-@use "scss/final";
-@use "scss/game-over";
+body.invalid {
+  // Teleported toast targets render into <body>, outside .invalid-view.
+  @include meta.load-css("scss/toasts");
+}
 
-// COMPONENTS
-@use "scss/mobile";
-@use "scss/toasts";
+// 3. VIEW
+.invalid-view {
+  // Site specific
+  @include meta.load-css("scss/default");
+  @include meta.load-css("scss/scores");
 
-// OTHER PAGES
-@use "scss/article";
+  // Screens
+  @include meta.load-css("scss/pregame");
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/admin");
+  @include meta.load-css("scss/employee");
+  @include meta.load-css("scss/crash");
+  @include meta.load-css("scss/final");
+  @include meta.load-css("scss/game-over");
 
-input.uppercase {
-  text-transform: uppercase;
+  // Components
+  @include meta.load-css("scss/mobile");
+
+  // Other pages
+  @include meta.load-css("scss/article");
+
+  input.uppercase {
+    text-transform: uppercase;
+  }
 }

--- a/src/views/invalid/scss/_default.scss
+++ b/src/views/invalid/scss/_default.scss
@@ -1,9 +1,5 @@
 @use "index" as *;
 
-[v-cloak] {
-  display: none !important;
-}
-
 h1 {
   font-size: 2rem;
 }
@@ -31,11 +27,6 @@ h5 {
   font-family: $headline-font;
 }
 
-body {
-  background: $body;
-  color: $copy;
-  font-family: $font-family;
-}
 img {
   max-width: 100%;
 }
@@ -61,15 +52,5 @@ ul {
 svg {
   path {
     fill: currentColor;
-  }
-}
-.v-toast {
-  font-family: $sans-serif;
-  h3 {
-    font-size: 140%;
-    margin-bottom: 0.5em;
-  }
-  .v-toast__item {
-    max-width: 320px;
   }
 }

--- a/src/views/invalid/scss/_document.scss
+++ b/src/views/invalid/scss/_document.scss
@@ -1,0 +1,27 @@
+@use "index" as *;
+
+// Document-level rules for invalid. Route-scoped via the `invalid` class
+// useGameHead adds to <html>/<body> (#292), so they can't bleed onto other
+// routes and a stale (dev HMR) copy from another view can't paint invalid.
+body.invalid {
+  background: $body;
+  color: $copy;
+  font-family: $font-family;
+
+  // Teleported toast target lives in <body>, outside .invalid-view.
+  .v-toast {
+    font-family: $sans-serif;
+    h3 {
+      font-size: 140%;
+      margin-bottom: 0.5em;
+    }
+    .v-toast__item {
+      max-width: 320px;
+    }
+  }
+}
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none !important;
+}

--- a/src/views/meeting/Meeting.scss
+++ b/src/views/meeting/Meeting.scss
@@ -1,89 +1,105 @@
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset + toast lib. Identical across views.
+//   2. DOCUMENT — teleported toast + tippy targets, route-scoped via the
+//                 `meeting` class useGameHead adds to <body>. (No html/body base
+//                 rules exist for this view, so there is no _document partial.)
+//   3. VIEW     — everything inside the .meeting-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
+@use "sass:meta";
+
+// Meeting members (variables) — needed by the inline VIEW/DOCUMENT rules below.
 @use "scss/index" as *;
 
-// Shared reset emits CSS (not members), so @use it directly, once.
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
-
-// LIBRARIES (if any)
 @use "@/shared/scss/libraries/vue_toastification";
 
-@use "scss/title-screen";
-@use "scss/pregame";
-@use "scss/players";
-@use "scss/cards";
-@use "scss/guess";
-@use "scss/animations";
-@use "scss/lemon-toast";
-@use "scss/game-over";
+// 2. DOCUMENT
+body.meeting {
+  // Teleported toast + tippy targets render into <body>, outside .meeting-view.
+  @include meta.load-css("scss/lemon-toast");
 
-.meeting-board {
-  display: grid;
-  grid-template-columns: 1fr $playerListWidth;
-  min-height: 100dvh;
-}
-
-.instructions {
-  color: white;
-  h1 {
-    font-size: 3rem;
+  .tippy-box {
+    background: $white;
+    color: #111;
+    .tippy-arrow {
+      color: $white;
+    }
+    &[data-theme="light"] {
+      background: $cream;
+      color: #222;
+      .tippy-arrow {
+        color: $cream;
+      }
+    }
+    .tippy-content {
+      font-family: $sans-serif;
+      font-weight: 525;
+      max-width: 160px;
+    }
   }
 }
 
-.timer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: $playerListWidth;
-  .bar {
-    position: absolute;
+// 3. VIEW
+.meeting-view {
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/pregame");
+  @include meta.load-css("scss/players");
+  @include meta.load-css("scss/cards");
+  @include meta.load-css("scss/guess");
+  @include meta.load-css("scss/animations");
+  @include meta.load-css("scss/game-over");
+
+  .meeting-board {
+    display: grid;
+    grid-template-columns: 1fr $playerListWidth;
+    min-height: 100dvh;
+  }
+
+  .instructions {
+    color: white;
+    h1 {
+      font-size: 3rem;
+    }
+  }
+
+  .timer {
+    position: fixed;
     bottom: 0;
     left: 0;
-    right: 0;
-    height: 32px;
-    background-color: black;
-    .fill {
+    right: $playerListWidth;
+    .bar {
       position: absolute;
-      top: 0;
-      left: 0;
       bottom: 0;
-      background: $yellow;
+      left: 0;
+      right: 0;
+      height: 32px;
+      background-color: black;
+      .fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        background: $yellow;
+      }
     }
-  }
-  .seconds-holder {
-    position: absolute;
-    bottom: 32px;
-    left: 0;
-    padding-left: 20px;
-    .seconds {
-      color: $yellow;
-      font-family: $monospace;
-      font-size: 2.5rem;
-      font-weight: 725;
+    .seconds-holder {
+      position: absolute;
+      bottom: 32px;
+      left: 0;
+      padding-left: 20px;
+      .seconds {
+        color: $yellow;
+        font-family: $monospace;
+        font-size: 2.5rem;
+        font-weight: 725;
+      }
+      .after-seconds {
+        color: $cream;
+        font-family: $sans-serif;
+        font-size: 1rem;
+        padding-left: 1em;
+      }
     }
-    .after-seconds {
-      color: $cream;
-      font-family: $sans-serif;
-      font-size: 1rem;
-      padding-left: 1em;
-    }
-  }
-}
-
-.tippy-box {
-  background: $white;
-  color: #111;
-  .tippy-arrow {
-    color: $white;
-  }
-  &[data-theme="light"] {
-    background: $cream;
-    color: #222;
-    .tippy-arrow {
-      color: $cream;
-    }
-  }
-  .tippy-content {
-    font-family: $sans-serif;
-    font-weight: 525;
-    max-width: 160px;
   }
 }

--- a/src/views/megachurch/Megachurch.scss
+++ b/src/views/megachurch/Megachurch.scss
@@ -1,29 +1,44 @@
-// GLOBALS: shared reset (emits CSS) + the toast library. Member-only globals
-// (variables/mixins/extends) are pulled in per-partial via scss/index.
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset, toast lib, and @keyframes (which hoist to the
+//                 top level regardless of nesting). Identical across views.
+//   2. DOCUMENT — html/body base + multiselect custom props + teleported toast
+//                 targets, route-scoped via useGameHead bodyClass: "megachurch".
+//   3. VIEW     — everything inside .megachurch-view, nested via meta.load-css.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
-
 @use "@/shared/scss/libraries/vue_toastification";
+@use "scss/animations"; // @keyframes only — hoisted to root
 
-@use "scss/defaults";
-@use "scss/animations";
-@use "scss/transitions";
+// 2. DOCUMENT
+@use "scss/document"; // html.megachurch (--ms-* vars) + body.megachurch base
 
-@use "scss/libraries/multiselect-custom";
-@use "scss/libraries/toastification-custom";
-@use "scss/lemon-toast";
+body.megachurch {
+  // Teleported toast targets render into <body>, outside .megachurch-view.
+  @include meta.load-css("scss/libraries/toastification-custom");
+  @include meta.load-css("scss/lemon-toast");
+}
 
-// Screens
-@use "scss/title-screen";
-@use "scss/form";
-@use "scss/choose";
-@use "scss/sermon";
-@use "scss/your-details";
-@use "scss/diagnosis";
-@use "scss/preaching";
-@use "scss/weekly-report";
-@use "scss/sermon-results";
-@use "scss/game-over";
-@use "scss/mobile-unscreen"; // Warning for smaller screens
+// 3. VIEW
+.megachurch-view {
+  @include meta.load-css("scss/defaults");
+  @include meta.load-css("scss/transitions");
+  @include meta.load-css("scss/libraries/multiselect-custom");
 
-// Components
-@use "scss/spice-warning";
+  // Screens
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/form");
+  @include meta.load-css("scss/choose");
+  @include meta.load-css("scss/sermon");
+  @include meta.load-css("scss/your-details");
+  @include meta.load-css("scss/diagnosis");
+  @include meta.load-css("scss/preaching");
+  @include meta.load-css("scss/weekly-report");
+  @include meta.load-css("scss/sermon-results");
+  @include meta.load-css("scss/game-over");
+  @include meta.load-css("scss/mobile-unscreen"); // Warning for smaller screens
+
+  // Components
+  @include meta.load-css("scss/spice-warning");
+}

--- a/src/views/megachurch/scss/_defaults.scss
+++ b/src/views/megachurch/scss/_defaults.scss
@@ -1,9 +1,5 @@
 @use "index" as *;
 
-body {
-  font-family: $sans-serif;
-  background-color: $white;
-}
 main {
   min-height: 100dvh;
   background-color: $white;

--- a/src/views/megachurch/scss/_document.scss
+++ b/src/views/megachurch/scss/_document.scss
@@ -1,0 +1,18 @@
+@use "index" as *;
+
+// Document-level rules for megachurch. Route-scoped via the `megachurch` class
+// useGameHead adds to <html>/<body> (#292) so they can't bleed onto other
+// routes (and a stale dev-HMR copy can't paint another view).
+
+html.megachurch {
+  // Custom props consumed by @vueform/multiselect's default.css. They live on
+  // the document root so they cascade into the (in-component) dropdown.
+  --ms-option-bg-selected-pointed: #{$multiselectDark};
+  --ms-option-bg-selected: #{$multiselectMid};
+  --ms-option-bg-pointed: #{$multiselectHighlight};
+}
+
+body.megachurch {
+  font-family: $sans-serif;
+  background-color: $white;
+}

--- a/src/views/megachurch/scss/libraries/_multiselect-custom.scss
+++ b/src/views/megachurch/scss/libraries/_multiselect-custom.scss
@@ -1,10 +1,5 @@
 @use "@/views/megachurch/scss/index" as *;
 
-:root {
-  --ms-option-bg-selected-pointed: #{$multiselectDark};
-  --ms-option-bg-selected: #{$multiselectMid};
-  --ms-option-bg-pointed: #{$multiselectHighlight};
-}
 .multiselect {
   border: none;
   font-family: $serif;

--- a/src/views/pretend/Pretend.scss
+++ b/src/views/pretend/Pretend.scss
@@ -1,9 +1,21 @@
-//GLOBALS, GET DEFAULTS
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset (identical across views).
+//   2. DOCUMENT — html base + global [v-cloak], route-scoped as html.pretend
+//                 (useGameHead bodyClass: "pretend"). No teleport targets here.
+//   3. VIEW     — everything inside the .pretend-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
 
-// SITE SPECIFIC
-@use "scss/main";
-@use "scss/sidebar";
-@use "scss/banner";
+// 2. DOCUMENT
+@use "scss/document";
 
-@use "scss/debug";
+// 3. VIEW
+.pretend-view {
+  @include meta.load-css("scss/main");
+  @include meta.load-css("scss/sidebar");
+  @include meta.load-css("scss/banner");
+  @include meta.load-css("scss/debug");
+}

--- a/src/views/pretend/scss/_document.scss
+++ b/src/views/pretend/scss/_document.scss
@@ -1,0 +1,14 @@
+@use "index" as *;
+
+// Document-level rules for pretend. Route-scoped via the `pretend` class
+// useGameHead adds to <html>/<body> (#292), so they can't bleed onto other
+// routes and a stale (dev HMR) copy from another view can't paint pretend.
+html.pretend {
+  background: $body;
+  color: $white;
+}
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none !important;
+}

--- a/src/views/pretend/scss/_main.scss
+++ b/src/views/pretend/scss/_main.scss
@@ -1,16 +1,6 @@
 @use "index" as *;
 @use "sass:color";
 
-[v-cloak] {
-  display: none !important;
-}
-
-//main { background:yellow; }
-html {
-  background: $body;
-  color: $white;
-}
-
 .screen {
   > figure {
     background-size: contain;

--- a/src/views/sisyphus/Sisyphus.scss
+++ b/src/views/sisyphus/Sisyphus.scss
@@ -1,16 +1,32 @@
-// GLOBALS: reset emits CSS (not members), so @use it directly, once.
-@use "scss/globals/reset";
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — own reset, [v-cloak] utility, 3rd-party libs + @keyframes
+//                 (keyframes hoist to root even when nested). Identical/harmless
+//                 across views, so a stale (dev HMR) copy after nav is benign.
+//   2. DOCUMENT — html/body base + teleported toast targets, route-scoped via
+//                 the `sisyphus` class useGameHead adds to <html>/<body>.
+//   3. VIEW     — everything inside .sisyphus-view, nested via meta.load-css so
+//                 no selector can match another route.
+@use "sass:meta";
 
-// LIBRARIES
+// 1. GLOBAL
+@use "scss/globals/reset"; // own reset: emits html/body/* rules, harmless
+@use "scss/partials/default"; // [v-cloak] hide-until-hydrated utility
 @use "@/shared/scss/libraries/animate";
 @use "@/shared/scss/libraries/vue_toastification";
 
-// SITE SPECIFIC (CSS-emitting partials; members come in via each partial's own
-// `@use "../index" as *`). Same order as the previous @import cascade.
-@use "scss/partials/default";
-@use "scss/partials/hill";
-@use "scss/partials/store";
-@use "scss/partials/inventory";
-@use "scss/partials/counter";
-@use "scss/partials/cheevos";
-@use "scss/partials/sidebar";
+// 2. DOCUMENT
+@use "scss/document"; // body.sisyphus base
+
+body.sisyphus {
+  // Teleported Vue-Toastification targets render into <body>, outside .sisyphus-view.
+  @include meta.load-css("scss/partials/cheevos");
+}
+
+// 3. VIEW — same order as the previous @use cascade.
+.sisyphus-view {
+  @include meta.load-css("scss/partials/hill");
+  @include meta.load-css("scss/partials/store");
+  @include meta.load-css("scss/partials/inventory");
+  @include meta.load-css("scss/partials/counter");
+  @include meta.load-css("scss/partials/sidebar");
+}

--- a/src/views/sisyphus/scss/_document.scss
+++ b/src/views/sisyphus/scss/_document.scss
@@ -1,0 +1,8 @@
+// Document-level rules for sisyphus. Route-scoped via the `sisyphus` class
+// useGameHead adds to <html>/<body> (#292), so they can't bleed onto other
+// routes and a stale (dev HMR) copy from another view can't paint sisyphus.
+body.sisyphus {
+  font-size: 14px;
+  height: initial;
+  background: #333;
+}

--- a/src/views/sisyphus/scss/partials/_default.scss
+++ b/src/views/sisyphus/scss/partials/_default.scss
@@ -1,7 +1,3 @@
 [v-cloak] {
   display: none !important;
 }
-body {
-  font-size: 14px;
-  height: initial;
-}

--- a/src/views/sisyphus/scss/partials/_hill.scss
+++ b/src/views/sisyphus/scss/partials/_hill.scss
@@ -1,8 +1,5 @@
 @use "../index" as *;
 
-body {
-  background: #333;
-}
 main {
   font-family: $font;
 }

--- a/src/views/stats/Stats.scss
+++ b/src/views/stats/Stats.scss
@@ -1,12 +1,25 @@
-// Shared reset emits CSS (not members), so @use it directly, once.
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset (identical across views).
+//   2. DOCUMENT — html/body base + teleported .v-toast, route-scoped as
+//                 html.stats / body.stats (useGameHead bodyClass: "stats").
+//   3. VIEW     — everything inside the .stats-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
 
-// SCREENS
-@use "scss/default";
-@use "scss/sections";
-@use "scss/general";
-@use "scss/tables";
-// `.stats-screen` lives in its own partial so it stays ordered before `mobile`
-// (whose media queries override it at equal specificity — source order matters).
-@use "scss/stats-screen";
-@use "scss/mobile";
+// 2. DOCUMENT
+@use "scss/document";
+
+// 3. VIEW
+.stats-view {
+  @include meta.load-css("scss/default");
+  @include meta.load-css("scss/sections");
+  @include meta.load-css("scss/general");
+  @include meta.load-css("scss/tables");
+  // `.stats-screen` stays ordered before `mobile` (whose media queries override
+  // it at equal specificity — source order matters).
+  @include meta.load-css("scss/stats-screen");
+  @include meta.load-css("scss/mobile");
+}

--- a/src/views/stats/scss/_default.scss
+++ b/src/views/stats/scss/_default.scss
@@ -1,20 +1,3 @@
-html {
-  background: radial-gradient(#353535, #161616);
-  color: #eee;
-  background-attachment: fixed;
-}
-html,
-body {
-  margin: 0;
-  padding: 0;
-}
 p {
   margin-bottom: 1em;
-}
-[v-cloak] {
-  display: none;
-}
-
-.v-toast {
-  font-family: "Lora", serif;
 }

--- a/src/views/stats/scss/_document.scss
+++ b/src/views/stats/scss/_document.scss
@@ -1,0 +1,26 @@
+@use "index" as *;
+
+// Document-level rules for stats. Route-scoped via the `stats` class useGameHead
+// adds to <html>/<body> (#292), so they can't bleed onto other routes and a
+// stale (dev HMR) copy from another view can't paint stats.
+html.stats {
+  background: radial-gradient(#353535, #161616);
+  color: #eee;
+  background-attachment: fixed;
+}
+html.stats,
+body.stats {
+  margin: 0;
+  padding: 0;
+}
+body.stats {
+  // Teleported toast target lives in <body>, outside .stats-view.
+  .v-toast {
+    font-family: "Lora", serif;
+  }
+}
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none;
+}

--- a/src/views/wrongest/Wrongest.scss
+++ b/src/views/wrongest/Wrongest.scss
@@ -1,19 +1,28 @@
-//GLOBALS, GET DEFAULTS
+// Per-route CSS isolation (#292). See cameo/Cameo.scss for the pattern.
+//   1. GLOBAL   — shared reset (identical across views).
+//   2. DOCUMENT — html/body base + teleported .v-toast, route-scoped as
+//                 html.wrongest / body.wrongest (useGameHead bodyClass: "wrongest").
+//   3. VIEW     — everything inside the .wrongest-view wrapper, nested via
+//                 meta.load-css so no selector can match another route.
+@use "sass:meta";
+
+// 1. GLOBAL
 @use "@/shared/scss/globals/reset";
 
-// LIBRARIES (if any)
+// 2. DOCUMENT
+@use "scss/document";
 
-// SITE SPECIFIC
-@use "scss/default";
-@use "scss/timer";
-@use "scss/round-indicator";
-@use "scss/sidebar";
-
-// SCREENS
-@use "scss/title-screen";
-@use "scss/deck-selection";
-@use "scss/pregame";
-@use "scss/player-list";
-@use "scss/presenting";
-@use "scss/voting";
-@use "scss/game-over";
+// 3. VIEW
+.wrongest-view {
+  @include meta.load-css("scss/default");
+  @include meta.load-css("scss/timer");
+  @include meta.load-css("scss/round-indicator");
+  @include meta.load-css("scss/sidebar");
+  @include meta.load-css("scss/title-screen");
+  @include meta.load-css("scss/deck-selection");
+  @include meta.load-css("scss/pregame");
+  @include meta.load-css("scss/player-list");
+  @include meta.load-css("scss/presenting");
+  @include meta.load-css("scss/voting");
+  @include meta.load-css("scss/game-over");
+}

--- a/src/views/wrongest/scss/_default.scss
+++ b/src/views/wrongest/scss/_default.scss
@@ -1,23 +1,10 @@
-@use "index" as *;
-
 @keyframes lobbyDotBounce {
   0%, 100% { transform: translateY(0); opacity: 1; }
   50% { transform: translateY(-8px); opacity: 0.25; }
 }
 
-[v-cloak] {
-  display: none;
-}
-html {
-  background: radial-gradient(#353535, #161616);
-  color: #eee;
-}
 p {
   margin-bottom: 1em;
-}
-
-.v-toast {
-  font-family: $font-family;
 }
 svg * {
   fill: currentColor;

--- a/src/views/wrongest/scss/_document.scss
+++ b/src/views/wrongest/scss/_document.scss
@@ -1,0 +1,20 @@
+@use "index" as *;
+
+// Document-level rules for wrongest. Route-scoped via the `wrongest` class
+// useGameHead adds to <html>/<body> (#292), so they can't bleed onto other
+// routes and a stale (dev HMR) copy from another view can't paint wrongest.
+html.wrongest {
+  background: radial-gradient(#353535, #161616);
+  color: #eee;
+}
+body.wrongest {
+  // Teleported toast target lives in <body>, outside .wrongest-view.
+  .v-toast {
+    font-family: $font-family;
+  }
+}
+
+// Standard hide-until-hydrated utility; harmless globally.
+[v-cloak] {
+  display: none;
+}


### PR DESCRIPTION
Closes #292.

## Problem

View stylesheets (`src/views/*/*.scss`, loaded via non-scoped `<style src>`) were global and shared generic selectors (`main.title-screen`, bare `body`/`main`, etc.). When two views' stylesheets coexisted in one document (dev HMR keeping a visited view's `<style>` injected across client-side nav), the last-loaded one won — e.g. Megachurch's warehouse background + red `<h1>` painting over the home game-picker.

## Approach

Every view entry now splits its CSS into three buckets:

1. **GLOBAL** (`@use`, unwrapped) — shared reset + 3rd-party libraries + bare `@keyframes`. Identical across views, so a stale (dev-HMR) copy is harmless.
2. **DOCUMENT** — `html`/`body`/`:root` base + teleported-element overrides (`.Vue-Toastification__*`, `.tippy*`, `.v-toast`, `.ui-pnotify`, `.multiselect`). Route-scoped as `html.<slug>` / `body.<slug>` via a new `bodyClass` option on `useGameHead` that adds the class to `<html>`/`<body>`.
3. **VIEW** — everything else, nested under a `.<slug>-view` wrapper (added in `app/pages/<slug>.vue`) using `@include meta.load-css(...)`, which nests a partial's CSS under a selector **without editing the partial's internals**.

On client-side navigation the wrapper element and the html/body route class are both removed, so a previously-visited view's still-injected `<style>` matches nothing. `cameo/Cameo.scss` is the canonical reference. The 404 view was already scoped under `.NotFoundPage`.

**Residual accepted globals** (unchanged): the shared reset, 3rd-party lib bundles, and `@keyframes` names (one global namespace — keep animation names view-unique).

## Acceptance criteria

- [x] Navigating game → home (client-side) in `nuxi dev` no longer shows the previous game's background/colors on home.
- [x] Toasts, tooltips, modals, and animate.css transitions still work (teleported targets route-scoped under `body.<slug>`, which reaches `<body>`).
- [x] No visual change to any game or home in a normal (full-load) production visit.

## Verification

- `sass:check` — clean (0 errors, 0 deprecations across 26 entries + 13 inline blocks)
- `nuxi typecheck` — passes
- `nuxi generate` — all 26 routes prerendered; built-CSS audit shows only the intended global reset unscoped
- **Playwright dev-nav test**: loaded `/megachurch`, then SPA-navigated to `/`. Megachurch's `<style>` stayed injected (the exact dev-HMR condition), yet home rendered its own colors with zero bleed — `body`/`html` class flipped `megachurch`→`home`, `.megachurch-view` gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)