### PR TITLE
Fix broken deploy: install Playwright Chromium in CI before verify

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -42,6 +42,16 @@ jobs:
           echo "📋 Verifying key dependencies..."
           bun pm ls nuxt vue
 
+      - name: Install Playwright browser
+        run: |
+          echo "🎭 Installing Playwright's Chromium (the verify harness's default browser)…"
+          # GitHub runners have CDN access, so use Playwright's own bundled
+          # Chromium (+ headless shell). The @sparticuz/chromium fallback is only
+          # for egress-restricted sandboxes and is gated behind
+          # VERIFY_SPARTICUZ_CHROMIUM. --with-deps pulls the OS libs headless
+          # Chromium needs on Linux.
+          bunx playwright install --with-deps chromium
+
       - name: Verify routes (prerender, hydration, redirects)
         run: |
           echo "🔎 Running the route verify harness…"


### PR DESCRIPTION
## Problem
The `Deploy to Firebase` workflow started failing at the **Verify routes** step after #295 merged:

```
FATAL: browserType.launch: Executable doesn't exist at
/home/runner/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
```

## Cause
#295 (task #4) made the verify harness default to Playwright's bundled Chromium and moved `@sparticuz/chromium` to an **optional peer dependency** gated behind `VERIFY_SPARTICUZ_CHROMIUM`. CI had been relying on `@sparticuz/chromium` being a hard dependency as its default browser and never ran `playwright install`, so once the default changed there was no browser to launch.

## Fix
Add a step to install Playwright's Chromium (+ headless shell) before the verify step. GitHub runners have CDN access — unlike the egress-restricted sandbox the `@sparticuz` fallback was built for — so Playwright's own browser is the correct first-class choice. `--with-deps` pulls the OS libraries headless Chromium needs on Linux.

The route checks themselves pass (verified 60/60 GREEN locally with `bun run verify --no-emulator`); the only gap was the missing browser binary in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)